### PR TITLE
Fix links and code samples

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,0 +1,10 @@
+blockquote {
+  --background: #f3f8f3;
+  --title: #489e49;
+  --border: #50af51;
+
+  background: var(--background);
+  padding: 1.33rem;
+  margin-left: 0;
+  border-left: 2px solid var(--border);
+}

--- a/docs/reference/objects/biography.md
+++ b/docs/reference/objects/biography.md
@@ -49,5 +49,5 @@ Returns the url for the biography's page in the site
 
 # biography.image
 
-Returns the biography's [image](undefined). 
+Returns the biography's [image]({% link docs/reference/objects/image.md %}). 
 

--- a/docs/reference/objects/company.md
+++ b/docs/reference/objects/company.md
@@ -9,18 +9,25 @@ Company is a _global_ variable, meaning it should always be accessible to you wh
 
 # company.products
 
-This will return an array of the companies published [products](undefined) excluding any private products
+This will return an array of the companies published [products]({% link docs/reference/objects/product/index.md %}) excluding any private products
 e.g.
+
+{% raw %}
+```liquid
+{% for product in company.products %}
+    {{ product.name }}
+{% endfor %}
+```
+{% endraw %}
+
 
 # company.series
 
-This will return an array of the companies [series](undefined)
-e.g.
+This will return an array of the companies [series]({% link docs/reference/objects/series.md %})
 
 # company.biographies
 
-This will return an array of the companies [biographies](undefined)
-e.g.
+This will return an array of the companies [biographies]({% link docs/reference/objects/biography.md %})
 
 # company.countries
 
@@ -49,9 +56,9 @@ Returns the twitter username set within My Site > Social
 
 # company.avatar_logo
 
-Returns the company's logo as an [image](undefined). The logo is set within Settings > Your Brand.
+Returns the company's logo as an [image]({% link docs/reference/objects/image.md %}). The logo is set within Settings > Your Brand.
 
 # company.logo
 
-Returns the company's workmark logo as an [image](undefined). The logo is set within Settings > Your Brand.
+Returns the company's workmark logo as an [image]({% link docs/reference/objects/image.md %}). The logo is set within Settings > Your Brand.
 

--- a/docs/reference/objects/footer/footer_item.md
+++ b/docs/reference/objects/footer/footer_item.md
@@ -7,6 +7,14 @@ parent: Footer
 When using a `item` object you have access to the following attributes
 Can be accessed on the footer object as below
 
+{% raw %}
+```liquid
+{% for item in footer.items %}    
+    <a href="{{item.path}}">{{item.label}}</a>
+{% endfor %}
+```
+{% endraw %}
+
 # item.path
 
 Returns the target url for the footer item
@@ -14,9 +22,3 @@ Returns the target url for the footer item
 # item.label
 
 Returns the label for the footer item
-
-# Easol badge
-
-You can add the easol badge to the footer using the below variable 
-
-

--- a/docs/reference/objects/footer/index.md
+++ b/docs/reference/objects/footer/index.md
@@ -18,6 +18,6 @@ Returns the text colour selected within My Site > Footer
 
 # footer.items
 
-Returns an array of the footer [items](undefined)
+Returns an array of the footer [items]({% link docs/reference/objects/footer/footer_item.md %})
 
 

--- a/docs/reference/objects/image.md
+++ b/docs/reference/objects/image.md
@@ -7,6 +7,14 @@ parent: Objects
 
 All images used in canvas themes have the following attributes
 
+> By using the most suitable url method you can help ensure faster load times on pages using the theme
+
+{% raw %}
+```html
+<img alt='{image.name}' src='{image.thumbnail_url}'/>
+```
+{% endraw %}
+
 # image.name
 
 The filename of the original image, useful for adding alt texts to the images.
@@ -16,10 +24,18 @@ The filename of the original image, useful for adding alt texts to the images.
 The original unedited url for the image
 This has alternatives for resizing the image as below
 
+
+| Attribute             | Maximum width (px)|
+|:----------------------|:------------------|
+| `image.thumbnail_url` | 405               |
+| `image.small_url`     | 540               |
+| `image.medium_url`    | 720               |
+| `image.large_url`     | 960               |
+| `image.xlarge_url`    | 1140              |
+| `image.xxlarge_url`   | 1920              |
+
 # image.signature
 
 A unique id for the image
-
-# 
 
 

--- a/docs/reference/objects/menu/index.md
+++ b/docs/reference/objects/menu/index.md
@@ -6,7 +6,8 @@ parent: Objects
 has_children: true
 ---
 
-Additional logos can be found within [Company](undefined)
+Additional logos can be found within [Company]({% link docs/reference/objects/company.md %})
+
 The `menu` object has the following attributes:
 
 # menu.background_colour
@@ -35,9 +36,9 @@ Returns the target url for the CTA
 
 # menu.brand_override
 
-Returns the brand override logo as an [image](undefined). 
+Returns the brand override logo as an [image]({% link docs/reference/objects/image.md %}). 
 
 # menu.items
 
-Returns an array of the menu [items](undefined)
+Returns an array of the menu [items]({% link docs/reference/objects/menu/menu_item.md %})
 

--- a/docs/reference/objects/menu/menu_item.md
+++ b/docs/reference/objects/menu/menu_item.md
@@ -1,10 +1,18 @@
 ---
 layout: default
-title: Menu Item
+title: Item
 parent: Menu
 ---
 When using a `item` object you have access to the following attributes
 Can be accessed on the menu object as below
+
+{% raw %}
+```liquid
+{% for item in menu.items %}    
+    <a href="{{item.path}}">{{item.label}}</a>
+{% endfor %}
+```
+{% endraw %}
 
 # item.path
 

--- a/docs/reference/objects/pagintation.md
+++ b/docs/reference/objects/pagintation.md
@@ -22,7 +22,7 @@ The page number currently being displayed, this is driven by a query param e.g. 
 
 # pagination.next
 
-Returns a [pagination link](undefined) to go to the next page, if there is no next page this won't be set
+Returns a pagination link to go to the next page, if there is no next page this won't be set
 
 # pagination.page_count
 
@@ -34,9 +34,9 @@ The maximum number of items displayed on each page
 
 # pagination.parts
 
-This returns an array of [pagination links](undefined) which represents links to specific page numbers of the collection, this handles abbreviation to an ellipsis if the number of pages is too high.
+This returns an array of pagination links which represents links to specific page numbers of the collection, this handles abbreviation to an ellipsis if the number of pages is too high.
 
 # pagination.previous
 
-Returns a [pagination link](undefined) to go to the previous page, if there is no previous page this won't be set
+Returns a pagination link to go to the previous page, if there is no previous page this won't be set
 

--- a/docs/reference/objects/product/accommodation.md
+++ b/docs/reference/objects/product/accommodation.md
@@ -20,7 +20,7 @@ Returns a unique id for the accommodation
 
 # accommodation.image
 
-Returns the accommodation [image](undefined)
+Returns the accommodation [image]({% link docs/reference/objects/image.md %})
 
 # accommodation.locale
 
@@ -33,7 +33,4 @@ Returns the name of the accommodation
 # accommodation.overview
 
 Returns the overview of the accommodation
-
-# 
-
 

--- a/docs/reference/objects/product/faq.md
+++ b/docs/reference/objects/product/faq.md
@@ -5,7 +5,6 @@ parent: Product
 ---
 
 When using an `faq` object you have access to the following attributes
-Can be accessed on a product like below
 
 # faq.answer
 

--- a/docs/reference/objects/product/highlight.md
+++ b/docs/reference/objects/product/highlight.md
@@ -21,8 +21,5 @@ Returns a unique id for the highlight
 
 # highlight.image
 
-Returns the highlights [image](undefined)
-
-# 
-
+Returns the highlights [image]({% link docs/reference/objects/image.md %})
 

--- a/docs/reference/objects/product/host.md
+++ b/docs/reference/objects/product/host.md
@@ -13,7 +13,7 @@ Returns the body of the host, this is a rich text field and so will return html 
 
 # host.image
 
-Returns the [image](undefined) of the host
+Returns the [image]({% link docs/reference/objects/image.md %}) of the host
 
 # host.instagram_username
 
@@ -26,7 +26,3 @@ Returns the name of the host
 # host_section.overview
 
 Returns the overview for the host section
-
-# 
-
-

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -10,11 +10,11 @@ When using a `product` object you have access to the following attributes
 
 # product.accommodations
 
-Returns an array of the products [accommodations](undefined)
+Returns an array of the products [accommodations]({% link docs/reference/objects/product/accommodation.md %})
 
 # product.address
 
-Returns the product [address](undefined)
+Returns the product [address]({% link docs/reference/objects/product/address.md %})
 
 # product.category
 
@@ -60,31 +60,31 @@ Returns an array of the products extras
 # product.facilities 
 
 Returns an array of the products facilities
-_Deprecated please use _[`whats_included.included`](https://app.gitbook.com/@fixers/s/canvas-developer/~/drafts/-Lq5lxwCSxv8n7gXxLxV/primary/objects/product#product-whats_included)
+_Deprecated please use _[`whats_included.included`]({% link docs/reference/objects/product/whats_included.md %}#whats_includedincluded)
 
 # product.hero_image
 
-Returns the products hero [image](undefined)
+Returns the products hero [image]({% link docs/reference/objects/image.md %})
 
 # product.faqs
 
-Returns an array of the products [faqs](undefined)
+Returns an array of the products [faqs]({% link docs/reference/objects/product/faq.md %})
 
 # product.featured_accommodations
 
-Returns an array of the products [accommodations](undefined) which are flagged as featured
+Returns an array of the products [accommodations]({% link docs/reference/objects/product/accommodation.md %}) which are flagged as featured
 
 # product.gallery
 
-Returns an array of [image objects](undefined) for the products gallery
+Returns an array of [image objects]({% link docs/reference/objects/image.md %}) for the products gallery
 
 # product.has_active_promotion
 
-Returns true if one of the [variants](undefined) in the product has an active [promotion](undefined)
+Returns true if one of the [variants]({% link docs/reference/objects/product/variant.md %}) in the product has an active [promotion]{% link docs/reference/objects/product/promotion.md %})
 
 # product.highlights
 
-Returns an array of the products [highlights](undefined)
+Returns an array of the products [highlights]({% link docs/reference/objects/product/highlight.md %})
 
 # product.host [ Deprecated, see product.host_section ]
 
@@ -93,7 +93,7 @@ Deprecated please use [`hosts`](https://app.gitbook.com/@fixers/s/canvas-develop
 
 # product.host_section
 
-Returns the product [host section](undefined)
+Returns the product [host section]({% link docs/reference/objects/product/host.md %})
 
 # product.id
 
@@ -123,7 +123,7 @@ Returns the overview of the product
 
 # product.overview_image
 
-Returns the products overview [image](undefined)
+Returns the products overview [image]({% link docs/reference/objects/image.md %})
 
 # product.remaining_stock
 
@@ -131,11 +131,11 @@ Returns the sum of remaining stock for a products variants, if any of the produc
 
 # product.schedule
 
-Returns an array of the products [schedule elements](undefined)
+Returns an array of the products [schedule elements]({% link docs/reference/objects/product/schedule_element.md %})
 
 # product.series
 
-If the product is in a series this will return a [series object](undefined)
+If the product is in a series this will return a [series object]({% link docs/reference/objects/series.md %})
 
 # product.shop_path
 
@@ -155,11 +155,11 @@ Returns the tagline of the product
 
 # product.testimonials
 
-Returns an array of the products [testimonials](undefined)
+Returns an array of the products [testimonials]({% link docs/reference/objects/product/testimonial.md %})
 
 # product.trip_tips
 
-Returns an array of the products [trip tips](undefined)
+Returns an array of the products [trip tips]({% link docs/reference/objects/product/trip_tip.md %})
 
 # product.url
 
@@ -167,17 +167,17 @@ Returns the url for the product's page in the site
 
 # product.useful_info
 
-Returns the product's [useful info](undefined)
+Returns the product's [useful info]({% link docs/reference/objects/product/useful_info.md %})
 
 # product.variants
 
-Returns an array of the products [variants](undefined).
+Returns an array of the products [variants]({% link docs/reference/objects/product/variant.md %}).
 
 # product.venue
 
-Returns the products [venue](undefined)
+Returns the products [venue]({% link docs/reference/objects/product/venue.md %})
 
 # product.whats_included
 
-Return the product [whats_included](https://app.gitbook.com/@fixers/s/canvas-developer/~/edit/drafts/-Lq5lxwCSxv8n7gXxLxV/objects/product/whats-included)
+Return the product [whats_included]({% link docs/reference/objects/product/whats_included.md %})
 

--- a/docs/reference/objects/product/promotion.md
+++ b/docs/reference/objects/product/promotion.md
@@ -5,7 +5,6 @@ parent: Product
 ---
 
 When using a `promotion` object you have access to the following attributes
-Can be accessed on a variant like below
 
 # promotion.active
 

--- a/docs/reference/objects/product/schedule_element.md
+++ b/docs/reference/objects/product/schedule_element.md
@@ -5,7 +5,6 @@ parent: Product
 ---
 
 When using a `schedule element` object you have access to the following attributes
-Can be accessed on a product like below
 
 # element.body
 
@@ -21,7 +20,7 @@ Returns a unique id for the schedule element
 
 # element.image
 
-Returns the [image](undefined) for the schedule element if present
+Returns the [image]({% link docs/reference/objects/image.md %}) for the schedule element if present
 
 # element.type
 
@@ -38,7 +37,4 @@ Returns an `Array` of `Strings`  with what's not included on this schedule eleme
 # element.locale
 
 Returns the locale for the schedule element
-
-# 
-
 

--- a/docs/reference/objects/product/testimonial.md
+++ b/docs/reference/objects/product/testimonial.md
@@ -5,7 +5,6 @@ parent: Product
 ---
 
 When using a `testimonial` object you have access to the following attributes
-Can be accessed on a product like below
 
 # testimonial.body
 
@@ -17,11 +16,11 @@ Returns a unique id for the testimonial
 
 # testimonial.image
 
-Returns the [image](undefined) for the testimonial if present
+Returns the [image]({% link docs/reference/objects/image.md %}) for the testimonial if present
 
 # testimonial.source_image
 
-Returns the [image](undefined) for the testimonial's source if present
+Returns the [image]({% link docs/reference/objects/image.md %}) for the testimonial's source if present
 
 # testimonial.source_link
 
@@ -30,7 +29,4 @@ Returns the url the testimonial has been attributed to
 # testimonial.source_name
 
 Returns the name for the source of the testimonial
-
-# 
-
 

--- a/docs/reference/objects/product/trip_tip.md
+++ b/docs/reference/objects/product/trip_tip.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Trip Tip
+parent: Product
+---
+
 When using a `Trip tip` object you have access to the following attributes
 Can be accessed on a product like below
 
@@ -15,8 +21,5 @@ Returns a unique id for the trip tip
 
 # trip_tip.image
 
-Returns the trip tips [image](undefined)
-
-# 
-
+Returns the trip tips [image]({% link docs/reference/objects/image.md %})
 

--- a/docs/reference/objects/product/useful_info.md
+++ b/docs/reference/objects/product/useful_info.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Useful Info
+parent: Product
+---
+
 The `useful_info` object has the following attributes
 
 # useful_info.check_in

--- a/docs/reference/objects/product/variant.md
+++ b/docs/reference/objects/product/variant.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Variant
+parent: Product
+---
+
 When using a `variant` object you have access to the following attributes
 Can be accessed on a product like below
 
@@ -11,7 +17,7 @@ Returns a unique id for the variant
 
 # variant.image
 
-Returns the variants [image](undefined) it it has one associated
+Returns the variants [image]({% link docs/reference/objects/image.md %}) it it has one associated
 
 # variant.minimum_nights
 
@@ -27,7 +33,7 @@ Returns the variants cheapest price per unit e.g. `$124 Per Room` or `$124 Per P
 
 # variant.promotion
 
-Returns the variants current active [promotion](undefined) if there is one
+Returns the variants current active [promotion]({% link docs/reference/objects/product/promotion.md %}) if there is one
 
 # variant.remaining_stock
 

--- a/docs/reference/objects/product/venue.md
+++ b/docs/reference/objects/product/venue.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Venue
+parent: Product
+---
+
 When using a `venue` object you have access to the following attributes
 Can be accessed on a product like below
 
@@ -15,12 +21,8 @@ Returns a unique id for the venue
 
 # venue.image
 
-Returns the venue's [image](undefined)
+Returns the venue's [image]({% link docs/reference/objects/image.md %})
 
 # venue.tagline
 
 Returns the tagline for the venue
-
-# 
-
-

--- a/docs/reference/objects/product/whats_included.md
+++ b/docs/reference/objects/product/whats_included.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Whats Included
+parent: Product
+---
+
 The `whats_included` object have the following attributes
 
 # whats_included.included

--- a/docs/reference/objects/series.md
+++ b/docs/reference/objects/series.md
@@ -18,11 +18,11 @@ Returns an array of the departure months of all upcoming products in the series
 
 # series.first_upcoming
 
-Returns the first upcoming [product](undefined) in the series
+Returns the first upcoming [product]({% link docs/reference/objects/product/index.md %}) in the series
 
 # series.first_upcoming_including_ongoing
 
-Returns the first upcoming [product](undefined) in the series, including any product that is taking place currently.
+Returns the first upcoming [product]({% link docs/reference/objects/product/index.md %}) in the series, including any product that is taking place currently.
 
 # series.id
 
@@ -34,7 +34,7 @@ Returns the name of the series
 
 # series.products
 
-Returns an array of published [products](undefined) in the series, both past and future
+Returns an array of published [products]({% link docs/reference/objects/product/index.md %}) in the series, both past and future
 
 # series.slug
 
@@ -42,9 +42,9 @@ Returns the unique slug used in a series url i.e. `domain.com/experiences/:serie
 
 # series.upcoming_products
 
-Returns an array of published [products](undefined) in the series which are upcoming
+Returns an array of published [products]({% link docs/reference/objects/product/index.md %}) in the series which are upcoming
 
 # series.upcoming_products_including_ongoing
 
-Returns an array of published [products](undefined) in the series which are taking place currently or are upcoming.
+Returns an array of published [products]({% link docs/reference/objects/product/index.md %}) in the series which are taking place currently or are upcoming.
 


### PR DESCRIPTION
We fix any undefined links after pulling over from Gitbook using the {%
link %} tag, we also replace any code sections that were in Gitbook and
not pulled over whilst we're in here