### PR TITLE
Add docs for new `type` methods on extra and variant

### DIFF
--- a/docs/reference/objects/product/extra.md
+++ b/docs/reference/objects/product/extra.md
@@ -123,3 +123,7 @@ Returns true if the extra is sold out.
 # extra.tagline
 
 Returns the extras tagline.
+
+# extra.type
+
+Will always return `"extra"`. This is useful when you have a list of `variant` and `extra` objects and you need to distinguish between them.

--- a/docs/reference/objects/product/variant.md
+++ b/docs/reference/objects/product/variant.md
@@ -59,3 +59,6 @@ Returns true if the variant is sold out
 
 Returns the variants tagline
 
+# variant.type
+
+Returns the type of this variant, one of `"experience_variant"` or `"accommodation_variant"`.


### PR DESCRIPTION
This is the documentation for the new `type` methods introduced in this Rails PR https://github.com/easolhq/easol/pull/6533.