### PR TITLE
Complete `blog_post_section` drop doc 

### DIFF
--- a/docs/reference/objects/product/address.md
+++ b/docs/reference/objects/product/address.md
@@ -3,7 +3,28 @@ layout: default
 title: Address
 parent: Product
 ---
-The `address` object has the following attributes
+The `address` object has the following attributes:
+
+# address.city
+
+Return the city for the address.
+
+# address.country
+
+It returns the country name for the corresponding `address.country_code`.
+
+# address.country_code
+
+It returns the official country code for the address. According to the [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166).
+
+# address.full_address
+
+A commodity method that return the address formatted using the attributes.
+Used on the example above.
+
+# address.id
+
+Returns a unique id for this address.
 
 # address.line_one
 
@@ -17,26 +38,6 @@ Return the second line of the address in plain text.
 
 Return the post code for the address.
 
-# address.city
-
-Return the city for the address.
-
-# address.country
-
-It returns the country name for the corresponding `address.country_code`
-
-# address.country_code
-
-It returns the official country code for the address. According to the [ISO 3166](https://en.wikipedia.org/wiki/ISO_3166).
-
-# address.full_address
-
-A commodity method that return the address formatted using the attributes.
-Used on the example above.
-
 # address.region
 
-It returns the region name for the corresponding `address.country_code`
-
-
-
+It returns the region name for the corresponding `address.country_code`.

--- a/docs/reference/objects/product/blog_post_section.md
+++ b/docs/reference/objects/product/blog_post_section.md
@@ -6,4 +6,6 @@ parent: Product
 
 When using a `blog_post_section` object you have access to the following attributes:
 
-TODO
+# blog_post_section.posts
+
+Returns an array of [blog posts]({% link docs/reference/objects/blog_post.md %}).

--- a/docs/reference/objects/product/faq.md
+++ b/docs/reference/objects/product/faq.md
@@ -4,7 +4,7 @@ title: FAQ
 parent: Product
 ---
 
-When using an `faq` object you have access to the following attributes
+When using an `faq` object you have access to the following attributes:
 
 # faq.answer
 
@@ -12,9 +12,8 @@ Returns the answer to the question, this is a rich text field and so will return
 
 # faq.id
 
-Returns a unique id for the faq
+Returns a unique id for the faq.
 
 # faq.question
 
-Returns the question related to the faq
-
+Returns the question related to the faq.

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -70,7 +70,7 @@ Returns an array of the products facilities
 
 # product.faqs
 
-Returns an array of the products [faqs]({% link docs/reference/objects/product/faq.md %})
+Returns an array of the product's [faqs]({% link docs/reference/objects/product/faq.md %}).
 
 # product.featured_accommodations
 

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -17,7 +17,7 @@ Returns the product [address]({% link docs/reference/objects/product/address.md 
 
 # product.blog_post_section
 
-Returns the blog post section]({% link docs/reference/objects/product/blog_post_section.md %})
+Returns the [blog post section]({% link docs/reference/objects/product/blog_post_section.md %}).
 
 # product.category
 


### PR DESCRIPTION
This PR also includes small tweaks to `address` and `faqs`.

This commits were on another branch that was deprecated but were left behind when we've migrated to the new `main` branch. This just bring them back without force pushing to `main`.