### PR TITLE
Add new `pre_checkout_modifier_groups` methods

### DIFF
--- a/docs/reference/objects/product/extra.md
+++ b/docs/reference/objects/product/extra.md
@@ -53,6 +53,10 @@ Returns the initial stock for the extra, if the extra has unlimited inventory th
 
 Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this extra.
 
+Note that the resulting list will encompass both pre- and post-checkout modifier groups, and therefore the use of this method in pre-checkout pages is not supported.
+
+For pre-checkout pages, [pre_checkout_modifier_groups]({% link docs/reference/objects/product/extra.md %}#extrapre_checkout_modifier_groups) should be used instead.
+
 # extra.name
 
 Returns the extras name.
@@ -88,6 +92,10 @@ Returns the [price]({% link docs/reference/objects/product/price.md %}) of this 
 > <p>{{extra.price}}</p>
 > ```
 > {% endraw %}
+
+# extra.pre_checkout_modifier_groups
+
+Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this extra that the user must choose before checking out.
 
 # extra.prices
 

--- a/docs/reference/objects/product/extra.md
+++ b/docs/reference/objects/product/extra.md
@@ -51,7 +51,7 @@ Returns the initial stock for the extra, if the extra has unlimited inventory th
 
 # extra.modifier_groups
 
-Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this extra.
+Returns a list of [modifier groups]({% link docs/reference/objects/product/modifier_group.md %}) associated with this extra.
 
 Note that the resulting list will encompass both pre- and post-checkout modifier groups, and therefore the use of this method in pre-checkout pages is not supported.
 
@@ -95,7 +95,7 @@ Returns the [price]({% link docs/reference/objects/product/price.md %}) of this 
 
 # extra.pre_checkout_modifier_groups
 
-Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this extra that the user must choose before checking out.
+Returns a list of [modifier groups]({% link docs/reference/objects/product/modifier_group.md %}) associated with this extra that the user must choose before checking out.
 
 # extra.prices
 

--- a/docs/reference/objects/product/modifier_group.md
+++ b/docs/reference/objects/product/modifier_group.md
@@ -20,7 +20,7 @@ The minimum number of modifiers that need to be selected in this group.
 
 # modifier_group.modifiers
 
-A list of the [modifiers](({% link docs/reference/objects/product/modifier.md %})) in this group.
+A list of the [modifiers]({% link docs/reference/objects/product/modifier.md %}) in this group.
 
 # modifier_group.name
 

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -75,7 +75,7 @@ Returns true whether this variant is priced per-person.
 
 # variant.modifier_groups
 
-Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this variant.
+Returns a list of [modifier groups]({% link docs/reference/objects/product/modifier_group.md %}) associated with this variant.
 
 Note that the resulting list will encompass both pre- and post-checkout modifier groups, and therefore the use of this method in pre-checkout pages is not supported.
 
@@ -101,7 +101,7 @@ A payment plan will still be returned if the price is less than the initial paym
 
 # variant.pre_checkout_modifier_groups
 
-Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this variant that the user must choose before checking out.
+Returns a list of [modifier groups]({% link docs/reference/objects/product/modifier_group.md %}) associated with this variant that the user must choose before checking out.
 
 # variant.price
 

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -77,6 +77,10 @@ Returns true whether this variant is priced per-person.
 
 Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this variant.
 
+Note that the resulting list will encompass both pre- and post-checkout modifier groups, and therefore the use of this method in pre-checkout pages is not supported.
+
+For pre-checkout pages, [pre_checkout_modifier_groups]({% link docs/reference/objects/product/variant/index.md %}#variantpre_checkout_modifier_groups) should be used instead.
+
 # variant.max_occupancy
 
 Returns the maximum number of guests for this variant.
@@ -94,6 +98,10 @@ Returns the variants name
 If the product this variant belongs to has a payment plan associated with it, this will return that [payment plan]({% link docs/reference/objects/product/variant/payment_plan.md %}).
 The payment plan won't be returned if the last payment date is after the start date of the experience.
 A payment plan will still be returned if the price is less than the initial payment, so this may return a payment plan that cannot be used for this variant.
+
+# variant.pre_checkout_modifier_groups
+
+Returns a list of [modifier groups](({% link docs/reference/objects/product/modifier_group.md %})) associated with this variant that the user must choose before checking out.
 
 # variant.price
 


### PR DESCRIPTION
These new methods are being made available to support custom booking journeys that require pre-checkout modifications to extras and variants. (The previously available `modifier_groups` may display post-checkout options which will break the booking logic if used pre-checkout.)