### PR TITLE
Documenting the Easol Badge Tag

### DIFF
--- a/docs/reference/tags/easol_badge_tag/index.md
+++ b/docs/reference/tags/easol_badge_tag/index.md
@@ -1,0 +1,22 @@
+---
+layout: default
+title: Easol Badge
+parent: Tags
+has_children: false
+---
+
+The Easol Badge Tag returns a HTML `<a>` Tag linking to easol.com
+
+##### input
+{% raw %}
+```liquid
+{% easol_badge %}
+```
+{% endraw %}
+
+##### output
+{% raw %}
+```html
+<a target="_blank\" style="font-size: 0.8rem;line-height: 1.33;letter-spacing: 0.166em;text-transform: uppercase;" rel="noopener\" href="https://easol.com?utm_content=creator_site_name&utm_medium=creator-site&utm_source=referral\">Powered by Easol Experience Commerce</a>
+```
+{% endraw %}


### PR DESCRIPTION
This commit adds documentation for the easol badge tag including an example of its liquid tag input and the rendered result.