### PR TITLE
Documenting the Item Selections Tag

### DIFF
--- a/docs/reference/tags/form_tags/item_selections/item_selections.md
+++ b/docs/reference/tags/form_tags/item_selections/item_selections.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Item Selections
+parent: Tags
+has_children: false
+---
+
+The Item Selections Tag returns an object which can be used as a wrapper to display modifiers for a given item.
+
+
+##### input
+{% raw %}
+```liquid
+    {% form 'item_selections', item %}
+    {% endform %}
+```
+{% endraw %}
+
+##### output
+{% raw %}
+```html
+<form action="/items/example/path/selections" accept-charset="UTF-8" method="post">
+    <input type="hidden" name="_method" value="put" autocomplete="off">
+    <input type="submit" id="save" value="Confirm my selections" disabled="">
+</form>
+```
+{% endraw %}
+
+##### Item param
+The item param is required
+
+##### Extra Params
+* `guest::` A guest ID is required when the modifiers has a guest


### PR DESCRIPTION
This commit adds documentation for the Item Selections Tag, including liquid tag input examples and the rendered result.

PLEASE NOTE: The file (docs/reference/tags/item_selections.md) will be moved and renamed when [this link](https://github.com/easolhq/easolhq.github.io/pull/57) has been merged. 