### PR TITLE
Add nav order to docs

### DIFF
--- a/docs/guides/best_practices/index.md
+++ b/docs/guides/best_practices/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Best Practices
 has_children: true
 parent: Guides
+nav_order: 17
 ---

--- a/docs/guides/cart_on_sites/index.md
+++ b/docs/guides/cart_on_sites/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Cart on Sites
 has_children: true
 parent: Guides
+nav_order: 12
 ---

--- a/docs/guides/cart_shop/index.md
+++ b/docs/guides/cart_shop/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Cart Shop
 has_children: true
 parent: Guides
+nav_order: 11
 ---

--- a/docs/guides/customer_terms/index.md
+++ b/docs/guides/customer_terms/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Customer Terms
 has_children: true
 parent: Guides
+nav_order: 14
 ---

--- a/docs/guides/dependencies/index.md
+++ b/docs/guides/dependencies/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Dependencies
 has_children: true
 parent: Guides
+nav_order: 2
 ---

--- a/docs/guides/developer_tools/index.md
+++ b/docs/guides/developer_tools/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Developer Tools
 has_children: true
 parent: Guides
+nav_order: 16
 ---

--- a/docs/guides/filters/index.md
+++ b/docs/guides/filters/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Theme Architecture
+title: Filters
 has_children: true
 parent: Guides
-nav_order: 4
+nav_order: 10
 ---

--- a/docs/guides/getting_started/index.md
+++ b/docs/guides/getting_started/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Getting Started
 has_children: true
 parent: Guides
+nav_order: 1
 ---

--- a/docs/guides/internationalisation/index.md
+++ b/docs/guides/internationalisation/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Internationalisation
 has_children: true
 parent: Guides
+nav_order: 13
 ---

--- a/docs/guides/pricing_and_payments/index.md
+++ b/docs/guides/pricing_and_payments/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Pricing & Payments
 has_children: true
 parent: Guides
+nav_order: 7
 ---

--- a/docs/guides/product_merchandising/index.md
+++ b/docs/guides/product_merchandising/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Product Merchandising
 has_children: true
 parent: Guides
+nav_order: 6
 ---

--- a/docs/guides/product_search/index.md
+++ b/docs/guides/product_search/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Product Search
 has_children: true
 parent: Guides
+nav_order: 8
 ---

--- a/docs/guides/seo/index.md
+++ b/docs/guides/seo/index.md
@@ -3,4 +3,5 @@ layout: default
 title: SEO
 has_children: true
 parent: Guides
+nav_order: 15
 ---

--- a/docs/guides/site_navigation/index.md
+++ b/docs/guides/site_navigation/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Site Navigation
 has_children: true
 parent: Guides
+nav_order: 5
 ---

--- a/docs/guides/site_styles/index.md
+++ b/docs/guides/site_styles/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Site Styles
 has_children: true
 parent: Guides
+nav_order: 3
 ---

--- a/docs/guides/tags/index.md
+++ b/docs/guides/tags/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
-title: Theme Architecture
+title: Tags
 has_children: true
 parent: Guides
-nav_order: 4
+nav_order: 9
 ---

--- a/docs/guides/troubleshooting/index.md
+++ b/docs/guides/troubleshooting/index.md
@@ -3,4 +3,5 @@ layout: default
 title: Troubleshooting
 has_children: true
 parent: Guides
+nav_order: 18
 ---


### PR DESCRIPTION
Currently the nav on easol.dev orders alphabetically. This sets an explicit order for the nav items.