### PR TITLE
Just direct to the tag reference docs

### DIFF
--- a/docs/guides/pricing_and_payments/index.md
+++ b/docs/guides/pricing_and_payments/index.md
@@ -5,3 +5,5 @@ has_children: true
 parent: Guides
 nav_order: 7
 ---
+
+Please see [Tags]({% link docs/guides/tags/index.md %}).


### PR DESCRIPTION
Think we're agreed that the reference documents will cover the basics, and use cases will come up in other sections.

Should this even exist? Thoughts?