### PR TITLE
Complete the family

### DIFF
--- a/docs/reference/filters/group_by.md
+++ b/docs/reference/filters/group_by.md
@@ -2,6 +2,7 @@
 layout: default
 title: Group By
 parent: Filters
+grand_parent: Reference
 ---
 
 # group_by

--- a/docs/reference/filters/money.md
+++ b/docs/reference/filters/money.md
@@ -2,6 +2,7 @@
 layout: default
 title: Money
 parent: Filters
+grand_parent: Reference
 ---
 
 # money

--- a/docs/reference/filters/pagination.md
+++ b/docs/reference/filters/pagination.md
@@ -2,6 +2,7 @@
 layout: default
 title: Pagination
 parent: Filters
+grand_parent: Reference
 ---
 
 # default_pagination

--- a/docs/reference/filters/parameterize.md
+++ b/docs/reference/filters/parameterize.md
@@ -2,6 +2,7 @@
 layout: default
 title: Parameterize
 parent: Filters
+grand_parent: Reference
 ---
 
 # parameterize

--- a/docs/reference/filters/words.md
+++ b/docs/reference/filters/words.md
@@ -2,6 +2,7 @@
 layout: default
 title: Words
 parent: Filters
+grand_parent: Reference
 ---
 
 # to_sentence

--- a/docs/reference/tags/accommodation_availability_tag/index.md
+++ b/docs/reference/tags/accommodation_availability_tag/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Accommodation Availability
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/cache_tag/index.md
+++ b/docs/reference/tags/cache_tag/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Cache
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/currency_switcher_tag/index.md
+++ b/docs/reference/tags/currency_switcher_tag/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Currency Switcher
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/easol_badge_tag/index.md
+++ b/docs/reference/tags/easol_badge_tag/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Easol Badge
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/form_tags/clear_cart/index.md
+++ b/docs/reference/tags/form_tags/clear_cart/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Clear Cart
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -2,6 +2,7 @@
 layout: default
 title: Create Line Item
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/form_tags/item_selections/item_selections.md
+++ b/docs/reference/tags/form_tags/item_selections/item_selections.md
@@ -2,6 +2,7 @@
 layout: default
 title: Item Selections
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/form_tags/remove_line_item/index.md
+++ b/docs/reference/tags/form_tags/remove_line_item/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Remove Line Item 
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 

--- a/docs/reference/tags/product_search/index.md
+++ b/docs/reference/tags/product_search/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Product Search
 parent: Tags
+grand_parent: Reference
 has_children: false
 ---
 


### PR DESCRIPTION
Currently clicking on a tag or filter is opening two sections in the docs navigation. 
Adding a grand_parent to tag and filter details to make position in navigation clearer.