### PR TITLE
Expand on product search

### DIFF
--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -4,3 +4,297 @@ title: Product Search
 has_children: true
 nav_order: 8
 ---
+
+# Product Search
+Product search is based on query parameters that determine which products are returned and in which order. In addition to the search query itself, there are parameters that allow you to customize the search further, for example you could:
+
+- Choose whether unavailable products are returned
+- Return only products with active promotions
+- Return products for a specific date range or year
+- Sort the results by departure date
+
+The product search is executed using the `product_search` [tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` search object. 
+
+{% raw %}
+```liquid
+{% product_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}
+    {% for item in result.items %}
+        <p>{{item.name}}</p>
+    {% endfor %}
+    <div>
+        {{paginate.collection_size}} Results
+        {{paginate | default_pagination}}
+    </div>
+{% endproduct_search %}
+```
+{% endraw %}
+
+It's also possible to pass search parameters as query params, this is useful when building dynamic search pages.
+
+{% raw %}
+```
+http://beyondadventures.com/search?search[name]=beyond&search[departure_date][greater_than]=2021-11-22&search[sort]=departure_date_asc
+```
+{% endraw %}
+
+> Note: Parameters passed through query params will overwrite any of those specified as an attribute on the product_search tag.
+
+## Pagination
+The results of the search are paginated in order to speed page load, you can define the number of results displayed per page using the `page_size` parameter.
+
+You can enable customers to move between the results pages using the `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
+
+
+## Parameters
+### active_promotion
+Accepts: `true` or `false`.<br>
+Passing `true` will return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search active_promotion: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[active_promotion]=true
+```
+
+### category
+Accepts any of the Easol predefined categories.<br>
+Will accept either a single category or an array.<br>
+Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search category: 'active' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[category]=active
+```
+
+### country
+Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names<br>
+Will accept either a single country or an array.<br>
+Will return products which match the country passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search country: 'FR' %}
+{% endproduct_search %}
+
+{% product_search country: ['FR','DE'] %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[country]=DE
+```
+
+### departure_date
+Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`.
+Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search departure_date: {greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-19&search[departure_date][less_than]=2023-12-28
+```
+
+### departure_month
+Accepts a month as either a 3 letter abreviation, or the month number i.e. `Apr` or `4`.<br>
+Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the month passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search departure_month: 'Apr' %}
+{% endproduct_search %}
+
+{% product_search departure_month: 4 %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[departure_month]=Apr
+https://mysite.com/search?search[departure_month]=4
+```
+
+### duration
+Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days.<br>
+Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.<br>
+Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search duration: {greater_than: 3, less_than: 8 } %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[duration][greater_than]=3&search[duration][less_than]=8
+```
+
+### exclude_sold_out_products
+Accepts: `true` or `false`.<br>
+Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search exclude_sold_out_products: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[exclude_sold_out_products]=true
+```
+
+### include_organisation_products
+Accepts: `true` or `false`.<br>
+Passing `true` will include products from other companies which are linked in the same organisation.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search include_organisation_products: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[include_organisation_products]=true
+```
+
+### name
+Executes a partial search on the string passed in.<br>
+Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search name: 'my experience' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[name]=my+experience
+```
+
+### series_id
+Accepts a series id.<br>
+Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search series_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
+```
+
+### subcategory
+Accepts any of the Easol predefined subcategories.<br>
+Will accept either a single subcategory or an array.<br>
+Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search subcategory: 'wellness' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[subcategory]=wellness
+```
+
+### page_size
+Accepts a number.<br>
+Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search page_size: 8 %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[page_size]=8
+```
+
+### sort
+Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.<br>
+Will determine the order of the returned products.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search sort: `departure_date_asc` %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[sort]=departure_date_asc
+```
+
+## Accessing query params
+Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that we can use the `search` object.
+
+##### syntax
+{% raw %}
+```
+{{search.departure_date}}
+```
+{% endraw %}
+
+## Sorting
+Results can be sorted asceding or descending by name, departure date or duration using the [sort]({% link docs/product_search/index.md %}#sort) parameter.
+
+##### syntax
+{% raw %}
+```
+{% product_search sort: `departure_date_asc` %}
+{% endproduct_search %}
+```
+{% endraw %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -13,7 +13,7 @@ Product search enables you to filter a Creator's experiences and accommodations,
 - Return products for a specific date range or year
 - Sort the results by departure date
 
-The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` search object. 
+The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` [Search]({% link docs/reference/objects/search_query.md %}) object. 
 
 The product search will only return products will only return public, published products i.e. experiences and accommodations which are published and have not been marked as private under 'Manage product availability' in the product settings.
 
@@ -64,7 +64,7 @@ You can enable customers to move between the results pages using the `paginate` 
 
 
 ## Accessing query params
-Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that we can use the `search` object.
+Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that we can use the `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
 
 ##### syntax
 {% raw %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Product Search
 has_children: true
 nav_order: 8
+has_toc: false
 ---
 
 # Product Search
@@ -13,7 +14,7 @@ Product search is based on query parameters that determine which products are re
 - Return products for a specific date range or year
 - Sort the results by departure date
 
-The product search is executed using the `product_search` [tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` search object. 
+The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` search object. 
 
 {% raw %}
 ```liquid
@@ -40,243 +41,26 @@ http://beyondadventures.com/search?search[name]=beyond&search[departure_date][gr
 > Note: Parameters passed through query params will overwrite any of those specified as an attribute on the product_search tag.
 
 ## Pagination
-The results of the search are paginated in order to speed page load, you can define the number of results displayed per page using the `page_size` parameter.
+The results of the search are paginated in order to speed page load, you can define the number of results displayed per page using the [page_size]({% link docs/product_search/parameters.md %}#page_size)parameter.
 
 You can enable customers to move between the results pages using the `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
 
 
 ## Parameters
-### active_promotion
-Accepts: `true` or `false`.<br>
-Passing `true` will return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
+- [active_promotion]({% link docs/product_search/parameters.md %}#active_promotion)
+- [category]({% link docs/product_search/parameters.md %}#category)
+- [country]({% link docs/product_search/parameters.md %}#country)
+- [departure_date]({% link docs/product_search/parameters.md %}#departure_date)
+- [departure_month]({% link docs/product_search/parameters.md %}#departure_month)
+- [duration]({% link docs/product_search/parameters.md %}#duration)
+- [exclude_sold_out_products]({% link docs/product_search/parameters.md %}#exclude_sold_out_products)
+- [include_organisation_products]({% link docs/product_search/parameters.md %}#include_organisation_products)
+- [name]({% link docs/product_search/parameters.md %}#name)
+- [series_id]({% link docs/product_search/parameters.md %}#series_id)
+- [subcategory]({% link docs/product_search/parameters.md %}#subcategory)
+- [page_size]({% link docs/product_search/parameters.md %}#page_size)
+- [sort]({% link docs/product_search/parameters.md %}#sort)
 
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search active_promotion: true %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[active_promotion]=true
-```
-
-### category
-Accepts any of the Easol predefined categories.<br>
-Will accept either a single category or an array.<br>
-Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search category: 'active' %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[category]=active
-```
-
-### country
-Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names<br>
-Will accept either a single country or an array.<br>
-Will return products which match the country passed.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search country: 'FR' %}
-{% endproduct_search %}
-
-{% product_search country: ['FR','DE'] %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[country]=DE
-```
-
-### departure_date
-Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`.
-Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search departure_date: {greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as query paramameters
-```
-https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-19&search[departure_date][less_than]=2023-12-28
-```
-
-### departure_month
-Accepts a month as either a 3 letter abreviation, or the month number i.e. `Apr` or `4`.<br>
-Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the month passed.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search departure_month: 'Apr' %}
-{% endproduct_search %}
-
-{% product_search departure_month: 4 %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as query paramameters
-```
-https://mysite.com/search?search[departure_month]=Apr
-https://mysite.com/search?search[departure_month]=4
-```
-
-### duration
-Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days.<br>
-Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.<br>
-Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search duration: {greater_than: 3, less_than: 8 } %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as query paramameters
-```
-https://mysite.com/search?search[duration][greater_than]=3&search[duration][less_than]=8
-```
-
-### exclude_sold_out_products
-Accepts: `true` or `false`.<br>
-Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search exclude_sold_out_products: true %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[exclude_sold_out_products]=true
-```
-
-### include_organisation_products
-Accepts: `true` or `false`.<br>
-Passing `true` will include products from other companies which are linked in the same organisation.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search include_organisation_products: true %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[include_organisation_products]=true
-```
-
-### name
-Executes a partial search on the string passed in.<br>
-Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search name: 'my experience' %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[name]=my+experience
-```
-
-### series_id
-Accepts a series id.<br>
-Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search series_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
-```
-
-### subcategory
-Accepts any of the Easol predefined subcategories.<br>
-Will accept either a single subcategory or an array.<br>
-Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search subcategory: 'wellness' %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[subcategory]=wellness
-```
-
-### page_size
-Accepts a number.<br>
-Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search page_size: 8 %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[page_size]=8
-```
-
-### sort
-Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.<br>
-Will determine the order of the returned products.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search sort: `departure_date_asc` %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[sort]=departure_date_asc
-```
 
 ## Accessing query params
 Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that we can use the `search` object.
@@ -289,7 +73,7 @@ Once the search has been executed, it can be helpful to get a reference to the p
 {% endraw %}
 
 ## Sorting
-Results can be sorted asceding or descending by name, departure date or duration using the [sort]({% link docs/product_search/index.md %}#sort) parameter.
+Results can be sorted asceding or descending by name, departure date or duration using the [sort]({% link docs/product_search/parameters.md %}#sort) parameter.
 
 ##### syntax
 {% raw %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -7,14 +7,15 @@ has_toc: false
 ---
 
 # Product Search
-Product search is based on query parameters that determine which products are returned and in which order. In addition to the search query itself, there are parameters that allow you to customize the search further, for example you could:
-
-- Choose whether unavailable products are returned
+Product search enables you to filter a Creator's experiences and accommodations, for example you could:
+- Choose whether sold out products are returned
 - Return only products with active promotions
 - Return products for a specific date range or year
 - Sort the results by departure date
 
 The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [pagination]({% link docs/reference/objects/pagination.md %}) object and  a `search` search object. 
+
+The product search will only return products will only return public, published products i.e. experiences and accommodations which are published and have not been marked as private under 'Manage product availability' in the product settings.
 
 {% raw %}
 ```liquid

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -5,7 +5,7 @@ parent: Product Search
 ---
 
 # Product Search Parameters
-Product search is based on query parameters that determine which products are returned and in which order.
+Product search is based on parameters that determine which products are returned and in which order.
 
 ### active_promotion
 Accepts: `true` or `false`.<br>
@@ -25,14 +25,18 @@ https://mysite.com/search?search[active_promotion]=true
 ```
 
 ### category
-Accepts any of the Easol predefined categories.<br>
+Accepts a string and is case-sensitive.<br>
+Currently the available Easol categories are: "Festival", "Wellness", "Adventure", "Food and Drink", "Active".<br>
 Will accept either a single category or an array.<br>
 Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search category: 'active' %}
+{% product_search category: 'Active' %}
+{% endproduct_search %}
+
+{% product_search subcategory: ['Active','Adventure'] %}
 {% endproduct_search %}
 ```
 {% endraw %}
@@ -82,7 +86,7 @@ https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-
 
 ### departure_month
 Accepts a month as either a 3 letter abreviation, or the month number i.e. `Apr` or `4`.<br>
-Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the month passed.
+Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the specified month, this may be across multiple years e.g. Apr 2023 and Apr 2024.
 
 ##### as a search tag attribute
 {% raw %}
@@ -104,7 +108,7 @@ https://mysite.com/search?search[departure_month]=4
 ### duration
 Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days.<br>
 Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.<br>
-Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days.
+Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days or number of hours. i.e. `duration: {equal_to: 2}` will return experiences that have a duration of 2 hours or 1 night (2 days).
 
 ##### as a search tag attribute
 {% raw %}
@@ -154,7 +158,7 @@ https://mysite.com/search?search[include_organisation_products]=true
 ```
 
 ### name
-Executes a partial search on the string passed in.<br>
+Executes a partial search on the string passed in. Case insensitive.<br>
 Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
 
 ##### as a search tag attribute
@@ -188,14 +192,17 @@ https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
 ```
 
 ### subcategory
-Accepts any of the Easol predefined subcategories.<br>
+Accepts a string and is case-sensitive.<br>
 Will accept either a single subcategory or an array.<br>
 Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search subcategory: 'wellness' %}
+{% product_search subcategory: 'Wellness' %}
+{% endproduct_search %}
+
+{% product_search subcategory: ['4 Star','5 Star'] %}
 {% endproduct_search %}
 ```
 {% endraw %}

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -1,0 +1,240 @@
+---
+layout: default
+title: Product Search Parameters
+parent: Product Search
+---
+
+# Product Search Parameters
+Product search is based on query parameters that determine which products are returned and in which order.
+
+### active_promotion
+Accepts: `true` or `false`.<br>
+Passing `true` will return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search active_promotion: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[active_promotion]=true
+```
+
+### category
+Accepts any of the Easol predefined categories.<br>
+Will accept either a single category or an array.<br>
+Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search category: 'active' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[category]=active
+```
+
+### country
+Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names<br>
+Will accept either a single country or an array.<br>
+Will return products which match the country passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search country: 'FR' %}
+{% endproduct_search %}
+
+{% product_search country: ['FR','DE'] %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[country]=DE
+```
+
+### departure_date
+Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`.
+Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search departure_date: {greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-19&search[departure_date][less_than]=2023-12-28
+```
+
+### departure_month
+Accepts a month as either a 3 letter abreviation, or the month number i.e. `Apr` or `4`.<br>
+Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the month passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search departure_month: 'Apr' %}
+{% endproduct_search %}
+
+{% product_search departure_month: 4 %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[departure_month]=Apr
+https://mysite.com/search?search[departure_month]=4
+```
+
+### duration
+Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days.<br>
+Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.<br>
+Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search duration: {greater_than: 3, less_than: 8 } %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as query paramameters
+```
+https://mysite.com/search?search[duration][greater_than]=3&search[duration][less_than]=8
+```
+
+### exclude_sold_out_products
+Accepts: `true` or `false`.<br>
+Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search exclude_sold_out_products: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[exclude_sold_out_products]=true
+```
+
+### include_organisation_products
+Accepts: `true` or `false`.<br>
+Passing `true` will include products from other companies which are linked in the same organisation.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search include_organisation_products: true %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[include_organisation_products]=true
+```
+
+### name
+Executes a partial search on the string passed in.<br>
+Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search name: 'my experience' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[name]=my+experience
+```
+
+### series_id
+Accepts a series id.<br>
+Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search series_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
+```
+
+### subcategory
+Accepts any of the Easol predefined subcategories.<br>
+Will accept either a single subcategory or an array.<br>
+Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search subcategory: 'wellness' %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[subcategory]=wellness
+```
+
+### page_size
+Accepts a number.<br>
+Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search page_size: 8 %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[page_size]=8
+```
+
+### sort
+Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.<br>
+Will determine the order of the returned products.
+
+##### as a search tag attribute
+{% raw %}
+```
+{% product_search sort: `departure_date_asc` %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### as a query paramameter
+```
+https://mysite.com/search?search[sort]=departure_date_asc
+```

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -216,6 +216,8 @@ https://mysite.com/search?search[subcategory]=wellness
 Accepts a number.<br>
 Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
 
+Page size cannot be passed as a query parameter.
+
 ##### as a search tag attribute
 {% raw %}
 ```
@@ -223,11 +225,6 @@ Will determine how many results are shown per page. If this is not included it w
 {% endproduct_search %}
 ```
 {% endraw %}
-
-##### as a query paramameter
-```
-https://mysite.com/search?search[page_size]=8
-```
 
 ### sort
 Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.<br>

--- a/docs/reference/objects/search_query.md
+++ b/docs/reference/objects/search_query.md
@@ -1,0 +1,42 @@
+---
+layout: default
+title: Search query
+parent: Objects
+---
+
+When using a `search` object each product search query parameter is available as an attribute.
+
+# search.active_promotion
+Returns `true` or `false`.
+
+# search.category
+Returns the category as a string.
+
+# search.country
+Returns the country as a string.
+
+# search.departure_date
+Returns the departure_date as an object i.e. `{"greater_than"=>"2022-11-19", "less_than"=>"2023-12-28"}`.
+Specific values can be accessed via: `search.departure_date.equal_to`, `search.departure_date.greater_than` and `search.departure_date.less_than` as relevant.
+
+# search.departure_month
+Returns the departure_month as a string in the form it was passed in i.e. `Jan` or `1`.
+
+# search.duration
+Returns the duration as an object i.e. `{"greater_than"=>"3", "less_than"=>"8"}`. 
+Specific values can be accessed via: `search.duration.equal_to`, `search.duration.greater_than` and `search.duration.less_than` as relevant.
+
+# search.exclude_sold_out_products
+Returns `true` or `false`.
+
+# search.include_organisation_products
+Returns `true` or `false`.
+
+# search.series_id
+Returns the series_id as a string.
+
+# search.subcategory
+Returns the subcategory as a string.
+
+# search.sort
+Returns `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` or `departure_date_desc`.


### PR DESCRIPTION
Adding additional examples and details on product search. I've included this as a separate section for review, to be consolidated with the existing product_search tag documentation at a later stage.