### PR TITLE
Add troubleshooting page

### DIFF
--- a/docs/carts/cart_interactions/add_line_items.md
+++ b/docs/carts/cart_interactions/add_line_items.md
@@ -61,3 +61,14 @@ To specify the adult count an additional input field is required, if no adult co
   <input type="hidden" name="items[][adult_count]" value="*<adult count>*" />
 ```
 {% endraw %}
+
+### Start on / End on
+Accommodation variants require a check in and check out date to be defined on the form. These are defined using start date and end date input fields.
+Dates should be formatted as `YYYY-MM-DD`.
+
+{% raw %}
+```liquid
+  <input type="hidden" name="items[][start_on]" value="*<YYYY-MM-DD>*">
+  <input type="hidden" name="items[][end_on]" value="*<YYYY-MM-DD>*">
+```
+{% endraw %}

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -7,7 +7,7 @@ has_children: false
 ---
 
 The Create Line Item Tag renders a form which acts as a wrapper for a single item.
-Extra HTML input tags can be used to add item quantity, modifiers or adult count for per-unit items
+Extra HTML input tags can be used to add item quantity, modifiers, adult count or start and end date.
 
 ##### input
 {% raw %}
@@ -47,10 +47,18 @@ Include a modifier
 ```
 {% endraw %}
 
-Specify adult count for a per-unit item
+Specify adult count for a per-unit item or accommodation
 {% raw %}
 ```html
   <input type="hidden" name="items[][adult_count]" value="**<adult count>**" />
+```
+{% endraw %}
+
+Specify start date and end date for accommodation items
+{% raw %}
+```html
+  <input type="hidden" name="items[][start_on]" value="**<YYYY-MM-DD>**">
+  <input type="hidden" name="items[][end_on]" value="**<YYYY-MM-DD>**">
 ```
 {% endraw %}
 
@@ -63,7 +71,7 @@ The following example redirects to the homepage.
 {% raw %}
 ```liquid
 {% form "create_line_item", return_to: '/home' %}
-      <input type="hidden" data-variant-id="{{item_id}}" name="items[][variant_id]" value="{{item_id}}"/>
+      <input type="hidden" name="items[][variant_id]" value="{{item_id}}"/>
  {% endform %}
 ```
 {% endraw %}

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -54,7 +54,7 @@ Specify adult count for a per-unit item or accommodation
 ```
 {% endraw %}
 
-Specify start date and end date for accommodation items
+Specify check in and check out dates for accommodation items
 {% raw %}
 ```html
   <input type="hidden" name="items[][start_on]" value="**<YYYY-MM-DD>**">

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -6,14 +6,14 @@ grand_parent: Reference
 has_children: false
 ---
 
-The Create Line Item Tag renders a form which acts as a wrapper for a single item.
+The Create Line Item Tag renders a form which acts as a wrapper for a single item, an item can be a [variant]({% link docs/reference/product/variant/index.md %}) or an [extra]({% link docs/reference/product/extra.md %}).
 Extra HTML input tags can be used to add item quantity, modifiers, adult count or start and end date.
 
 ##### input
 {% raw %}
 ```liquid
     {% form "create_line_item" %}
-        <input type="hidden" name="items[][variant_id]" value="{{item_id}}"/>
+        <input type="hidden" name="items[][variant_id]" value="**<variant.id or extra.id>**"/>
     {% endform %}
 ```
 {% endraw %}
@@ -29,7 +29,7 @@ Extra HTML input tags can be used to add item quantity, modifiers, adult count o
 {% endraw %}
 
 ##### HTML Input
-The HTML input requires `type="hidden"` and `value="item_id"`
+The HTML input requires 
 
 ##### Extra HTML input tags
 
@@ -40,10 +40,10 @@ Specify quantity
 ```
 {% endraw %}
 
-Include a modifier
+Include a modifier by referencing the [modifier.id]({% link docs/reference/product/modifier.md %})
 {% raw %}
 ```html
-  <input type="hidden" name="items[][modifier_ids][]" value="**<modifier id>**" />
+  <input type="hidden" name="items[][modifier_ids][]" value="**<modifier.id>**" />
 ```
 {% endraw %}
 

--- a/docs/troubleshooting/add_to_cart_failure.md
+++ b/docs/troubleshooting/add_to_cart_failure.md
@@ -1,0 +1,30 @@
+---
+layout: default
+title: Item not added to cart
+parent: Troubleshooting
+---
+
+## Items are not added to a customer's cart when submitting a create_line_item form
+
+For quick reference, see [create_line_item]({% link docs/carts/cart_interactions/add_line_items.md %})
+
+When adding an item to a cart, all relevant information needs to be included in the form to ensure the item is added successfully. The information required depends on the configuration of the experience.
+
+If your form is failing to add items to a customer's cart, below are some initial troubleshooting steps.
+
+- Which product shape is failing to add to the cart. Is it all experiences and accommodations, or just a subset?
+- Are all required input fields included. If only some experiences or accommodations are failing to be added to the cart, are there some fields missing?
+- Do the failing items have modifier groups assigned to them, and if so, have these been included in the form?
+- Is the item sold out, or is the specified modification option sold out? If so, add support to display items as [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) and hide the add to cart form.
+
+
+### Breakdown of form fields
+
+| Field         | Required on                                   |
+|:--------------|:----------------------------------------------|
+| variant_id    | All variants                                  |
+| quantity      | All variants                                  |
+| modifier_ids  | All variants with modifications               |
+| adult_count   | All accommodation variants, per unit variants |
+| start_on      | All accommodation variants                    |
+| end_on        | All accommodation variants                    |

--- a/docs/troubleshooting/index.md
+++ b/docs/troubleshooting/index.md
@@ -3,4 +3,13 @@ layout: default
 title: Troubleshooting
 has_children: true
 nav_order: 18
+has_toc: false
 ---
+
+# Troubleshooting
+
+- [Items are not added to a customer's cart when submitting a create_line_item form]({% link docs/troubleshooting/add_to_cart_failure.md %})
+
+* * *
+
+### Have more questions? [Submit a support request](https://support.easol.com/hc/en-gb/requests/new)


### PR DESCRIPTION
Adds a troubleshooting page and an initial troubleshooting article for add_line_item forms.
While writing the article I realised the start_date and end_date inputs had not been included in the docs, so these have now also been added.