### PR TITLE
Add details on clear_cart input

### DIFF
--- a/docs/carts/cart_interactions/add_line_items.md
+++ b/docs/carts/cart_interactions/add_line_items.md
@@ -72,3 +72,12 @@ Dates should be formatted as `YYYY-MM-DD`.
   <input type="hidden" name="items[][end_on]" value="*<YYYY-MM-DD>*">
 ```
 {% endraw %}
+
+### Clear cart
+In some instances you may want to clear all existing items out of a customer's cart before adding new items, this can be done by adding an additional `clear_cart` input field.
+
+{% raw %}
+```liquid
+  <input type="hidden" name="clear_cart">
+```
+{% endraw %}

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -28,9 +28,6 @@ Extra HTML input tags can be used to add item quantity, modifiers, adult count o
 ```
 {% endraw %}
 
-##### HTML Input
-The HTML input requires 
-
 ##### Extra HTML input tags
 
 Specify quantity

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -62,6 +62,13 @@ Specify check in and check out dates for accommodation items
 ```
 {% endraw %}
 
+Clear all existing items out of a customer's cart before adding new items.
+{% raw %}
+```html
+  <input type="hidden" name="clear_cart">
+```
+{% endraw %}
+
 
 ##### Extra Params
 * `return_to:` To specify the redirect location, pass a URL as the value of the return_to: param.


### PR DESCRIPTION
When using a `create_line_item` form it is also possible to clear the customer's cart before adding the new line items.
This adds details on how this can be done into the cart interactions guide and the quick reference area.