### PR TITLE
Fix broken links in the reference index page

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -8,6 +8,6 @@ has_toc: false
 # Reference
 
 - [Liquid template language](https://shopify.github.io/liquid/)
-- [Objects](% link docs/reference/objects/index.md %)
-- [Tags](% link docs/reference/tags/index.md %)
-- [Filters](% link docs/reference/filters/index.md %)
+- [Objects]({% link docs/reference/objects/index.md %})
+- [Tags]({% link docs/reference/tags/index.md %})
+- [Filters]({% link docs/reference/filters/index.md %})


### PR DESCRIPTION
Noticed the links here weren't working https://easol.dev/docs/reference/
Needs proper liquid tags