### PR TITLE
Product search

### DIFF
--- a/docs/carts/cart_display.md
+++ b/docs/carts/cart_display.md
@@ -15,14 +15,14 @@ The prices can be formatted in the customer's currency by applying the [money fi
 ##### syntax
 {% raw %}
 ```
-SUBTOTAL: {{cart.subtotal | money}}
+SUBTOTAL: {{ cart.subtotal | money }}
 
-DISCOUNT: {{cart.total_price_reduction | money}}
-BOOKING FEE: {{cart.total_fee | money}}
+DISCOUNT: {{ cart.total_price_reduction | money }}
+BOOKING FEE: {{ cart.total_fee | money }}
 
-TOTAL: {{cart.total | money}}
+TOTAL: {{ cart.total | money }}
 
-Pay with a deposit of {{cart.total_deposit | money}} or with a first instalment of {{cart.first_instalment_amount | money}}.
+Pay with a deposit of {{ cart.total_deposit | money }} or with a first instalment of {{ cart.first_instalment_amount | money }}.
 ```
 {% endraw %}
 
@@ -37,9 +37,9 @@ A breakdown of the items in a customer's cart can be displayed by looping throug
 {% raw %}
 ```
 {% for item in cart.items %}
-    {{item.quantity}}x {{item.variant_name}}
+    {{ item.quantity }}x {{ item.variant_name }}
     {% if item.adult_count %}
-        {{item.adult_count}} {% if item.adult_count == 1 %}person{% else %}people{% endif %}
+        {{ item.adult_count }} {% if item.adult_count == 1 %}person{% else %}people{% endif %}
     {% endif %}
 {% endfor %}
 ```
@@ -51,13 +51,13 @@ Creators may choose to provide customers with additional modification options, s
 {% raw %}
 ```
 {% for item in cart.items %}
-    {{item.quantity}}x {{item.variant_name}}
+    {{ item.quantity }}x {{ item.variant_name }}
     {% if item.adult_count %}
-        {{item.adult_count}} {% if item.adult_count == 1 %}person{% else %}people{% endif %}
+        {{ item.adult_count }} {% if item.adult_count == 1 %}person{% else %}people{% endif %}
     {% endif %}
     {% for selection in item.selections %}
-        {{selection.modifier_name}}
-        {{selection.price | money}}
+        {{ selection.modifier_name }}
+        {{ selection.price | money }}
     {% endfor %}
 {% endfor %}
 ```

--- a/docs/carts/cart_interactions/add_line_items.md
+++ b/docs/carts/cart_interactions/add_line_items.md
@@ -13,7 +13,7 @@ To add an item to a customer's cart you must include a [create_line_item tag]({%
 ```liquid
 {% for item in product.variants %}
     {% form "create_line_item" %}
-        <input type="hidden" name="items[][variant_id]" value="{{item.id}}" />
+        <input type="hidden" name="items[][variant_id]" value="{{ item.id }}" />
         <input type="submit" value="Add to cart" />
     {% endform %}
 {% endfor %}

--- a/docs/carts/cart_interactions/remove_line_items.md
+++ b/docs/carts/cart_interactions/remove_line_items.md
@@ -14,7 +14,7 @@ You can give customers the option to remove a line item from their cart. This is
 {% for item in cart.items %}
     {% form 'remove_line_item' %}
         <!-- line item info -->
-        <input name="items[]" value="{{item.id}}" type="hidden" />
+        <input name="items[]" value="{{ item.id }}" type="hidden" />
         <input type="submit" value="Remove" />
     {% endform %}
 {% endfor %}

--- a/docs/pricing_and_payments/deposits.md
+++ b/docs/pricing_and_payments/deposits.md
@@ -41,7 +41,7 @@ Display the deposit at the product level (i.e. only the featured variant):
 {% if deposit_active == true and cheapest_price != 0 %}
     {% assign deposit_price = cheapest_price | times: deposit_rate | money %}
 
-    <p>PAY ONLY {{deposit_price}} DEPOSIT</p>
+    <p>PAY ONLY {{ deposit_price }} DEPOSIT</p>
 
 {% endif %}
 ```
@@ -58,7 +58,7 @@ When displaying a series summary, the approach is similar (i.e. only the feature
 {% if deposit_active == true and cheapest_price != 0 %}
     {% assign deposit_price = cheapest_price | times: deposit_rate | money %}
 
-    <p>PAY ONLY {{deposit_price}} DEPOSIT</p>
+    <p>PAY ONLY {{ deposit_price }} DEPOSIT</p>
 
 {% endif %}
 ```
@@ -72,7 +72,7 @@ You may wish to display the deposit amount for each variant or extra when loopin
     {% if deposit_active == true and cheapest_price != 0 %}
         {% assign deposit_price = cheapest_price | times: deposit_rate | money %}
 
-        <p>PAY ONLY {{deposit_price}} DEPOSIT</p>
+        <p>PAY ONLY {{ deposit_price }} DEPOSIT</p>
 
     {% endif %}
 {% endfor %}

--- a/docs/pricing_and_payments/payment_plans.md
+++ b/docs/pricing_and_payments/payment_plans.md
@@ -31,7 +31,7 @@ To display the payment plan in Sites, note;
         {% assign initial_payment = lowest_price | divided_by: variant.payment_plan.number_of_instalments | money %}
     {% endif %}
 
-    <p>Pay just {{initial_payment}} today, and spread the remaining cost over {{variant.payment_plan.number_of_instalments | minus: 1 }} months</p>
+    <p>Pay just {{ initial_payment }} today, and spread the remaining cost over {{ variant.payment_plan.number_of_instalments | minus: 1 }} months</p>
 {% endif %}
 ```
 {% endraw %}

--- a/docs/pricing_and_payments/per_person_unit_or_night.md
+++ b/docs/pricing_and_payments/per_person_unit_or_night.md
@@ -65,7 +65,7 @@ E.g.
 ```liquid
  {% accommodation_availability variant %}
     {% for day in result.days %}
-        <p>On {{day.date | date:"%b %d, %y"}}</p>
+        <p>On {{ day.date | date:"%b %d, %y" }}</p>
         {% for price in day.prices %}
             <p>The price for {{ price.occupancy }} adult(s) is {{ price.fractional | money }}</p>
         {% endfor %}

--- a/docs/pricing_and_payments/price_formatting.md
+++ b/docs/pricing_and_payments/price_formatting.md
@@ -8,7 +8,7 @@ parent: Pricing & payments
 
 If no method is called on a [Price]({% link docs/reference/objects/product/price.md %}) object, it will default to showing with the currency symbol and either /pp or /night depending on the [per person, unit, or night pricing]({% link docs/pricing_and_payments/per_person_unit_or_night.md %}).
 
-e.g. {% raw %}`{{variant.price}}`{% endraw %} might render as €200.00/pp 
+e.g. {% raw %}`{{ variant.price }}`{% endraw %} might render as €200.00/pp 
 
 This is great for basic use cases. However, if a [Price]({% link docs/reference/objects/product/price.md %}) object has had a method called on it, e.g. when applying [promotions]({% link docs/pricing_and_payments/promotions.md %}) the return value is another drop.
 
@@ -16,6 +16,6 @@ e.g {% raw %}`{{ variant.price | apply_promotion: variant.promotion }}`{% endraw
 
 To format prices consistently across a site, we therefore recommend always using the `fractional` or `per_person_fractional` prices, applying the [money filter]({%link docs/reference/filters/money.md%}), and adding a suffix of per _something_ where needed. You can further format prices with the money filter attribute `no_cents_if_whole`
 
-e.g. {% raw %}`{{variant.price | money }}`{% endraw %} might render as €200.00<br>
-so   {% raw %}`{{variant.price.fractional | money: no_cents_if_whole: true}}`{% endraw %} would render as €200<br>
-and  {% raw %}`{{variant.price.per_person_fractional | money: no_cents_if_whole: true }}`{% endraw %} might render as €100
+e.g. {% raw %}`{{ variant.price | money }}`{% endraw %} might render as €200.00<br>
+so   {% raw %}`{{ variant.price.fractional | money: no_cents_if_whole: true }}`{% endraw %} would render as €200<br>
+and  {% raw %}`{{ variant.price.per_person_fractional | money: no_cents_if_whole: true }}`{% endraw %} might render as €100

--- a/docs/pricing_and_payments/price_tiers_and_occupancy.md
+++ b/docs/pricing_and_payments/price_tiers_and_occupancy.md
@@ -15,7 +15,7 @@ The variant method `.prices` will return an array containing the prices of each 
 E.g.
 {% raw %}
 ```liquid
-<h4>{{variant.name}}</h4>
+<h4>{{ variant.name }}</h4>
  {% for tiered_price in variant.prices %}
     <p>The price for {{ tiered_price.occupancy }} adult(s) is {{ tiered_price.fractional | money }}</p>
 {% endfor %}
@@ -55,7 +55,7 @@ E.g.
 ```liquid
  {% accommodation_availability variant %}
     {% for day in result.days %}
-        <p>On {{day.date | date:"%b %d, %y"}}</p>
+        <p>On {{ day.date | date:"%b %d, %y" }}</p>
         {% for price in day.prices %}
             <p>The price for {{ price.occupancy }} adult(s) is {{ price.fractional | money }}</p>
         {% endfor %}

--- a/docs/pricing_and_payments/promotions.md
+++ b/docs/pricing_and_payments/promotions.md
@@ -33,11 +33,11 @@ Creators want to advertise promotions as often as possible on their websites and
     {% endif %}
 
     <div>
-        <p>{{variant.name}}</p> 
+        <p>{{ variant.name }}</p> 
         {% if has_promotion %}
-        <p> Save {{promo_discount_amount}} with our <span class="promo-label">{{promo_category}} offer</span></p>
-        {% if promo_tagline != "" %}<p>{{promo_tagline}}</p>{% endif %}
-        {% if promo_expiry %}<p>Offer ends {{promo_expiry | date: "%d %B %Y"}}</p>{% endif %}
+        <p> Save {{ promo_discount_amount }} with our <span class="promo-label">{{ promo_category }} offer</span></p>
+        {% if promo_tagline != "" %}<p>{{ promo_tagline }}</p>{% endif %}
+        {% if promo_expiry %}<p>Offer ends {{ promo_expiry | date: "%d %B %Y" }}</p>{% endif %}
         {% endif %}
     </div>
 
@@ -73,11 +73,11 @@ This might render:
         {% assign promo_price = promo_price_drop.fractional | money %}
     {% endif %}
         
-    <p>{{variant.name}}</p> 
+    <p>{{ variant.name }}</p> 
     {% if has_promotion %}
-        <p>Price reduced from {{full_price}} to {{promo_price}}</p>
+        <p>Price reduced from {{ full_price }} to {{ promo_price }}</p>
     {% else %}
-        <p>Price is {{full_price}} </p>
+        <p>Price is {{ full_price }} </p>
     {% endif %}
 
 {% endfor %}

--- a/docs/product_management_and_merchandising/extras.md
+++ b/docs/product_management_and_merchandising/extras.md
@@ -19,10 +19,10 @@ Some things to consider when displaying a product's extras;
 ```liquid
 {% assign extra_groups = product.extras | group_by: "segment_name" | sort: "segment_name" %}
 {% for group in extra_groups %}
-    <h2>{{group.name}}</h2>
+    <h2>{{ group.name }}</h2>
     <ul>
         {% for extra in group.items %}
-             <li>{{extra.name}}</li>
+             <li>{{ extra.name }}</li>
         {% endfor %}
     </ul>
 {% endfor %}

--- a/docs/product_management_and_merchandising/variants.md
+++ b/docs/product_management_and_merchandising/variants.md
@@ -18,10 +18,10 @@ Some things to consider when displaying a product's variants:
 ```liquid
 {% assign variant_groups = product.variants | group_by: "segment_name" | sort: "segment_name" %}
 {% for group in variant_groups %}
-    <h2>{{group.name}}</h2>
+    <h2>{{ group.name }}</h2>
     <ul>
         {% for variant in group.items %}
-             <li>{{variant.name}}</li>
+             <li>{{ variant.name }}</li>
         {% endfor %}
     </ul>
 {% endfor %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -23,13 +23,13 @@ The product search will only return products will only return public, published 
 {% raw %}
 ```liquid
 {% product_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}
-    {% for item in result.items %}
-        <p>{{ item.name }}</p>
-    {% endfor %}
-    <div>
-        {{ paginate.collection_size }} Results
-        {{ paginate | default_pagination }}
-    </div>
+  {% for item in result.items %}
+    <p>{{ item.name }}</p>
+  {% endfor %}
+  <div>
+    {{ paginate.collection_size }} Results
+    {{ paginate | default_pagination }}
+  </div>
 {% endproduct_search %}
 ```
 {% endraw %}
@@ -55,13 +55,13 @@ You can assign the value of a liquid variable to `page_size`. You should update 
 ```liquid
 {% assign page_size = opt_selected_by_user %}
 {% product_search page_size: page_size, sort: 'departure_date_asc' %}
-    {% for item in result.items %}
-        <p>{{ item.name }}</p>
-    {% endfor %}
-    <div>
-        {{ paginate.page_size }} Results <!-- Updated results number -->
-        {{ paginate | default_pagination }}
-    </div>
+  {% for item in result.items %}
+    <p>{{ item.name }}</p>
+  {% endfor %}
+  <div>
+    {{ paginate.page_size }} Results <!-- Updated results number -->
+    {{ paginate | default_pagination }}
+  </div>
 {% endproduct_search %}
 ```
 {% endraw %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -24,11 +24,11 @@ The product search will only return products will only return public, published 
 ```liquid
 {% product_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}
     {% for item in result.items %}
-        <p>{{item.name}}</p>
+        <p>{{ item.name }}</p>
     {% endfor %}
     <div>
-        {{paginate.collection_size}} Results
-        {{paginate | default_pagination}}
+        {{ paginate.collection_size }} Results
+        {{ paginate | default_pagination }}
     </div>
 {% endproduct_search %}
 ```
@@ -56,11 +56,11 @@ You can assign the value of a liquid variable to `page_size`. You should update 
 {% assign page_size = opt_selected_by_user %}
 {% product_search page_size: page_size, sort: 'departure_date_asc' %}
     {% for item in result.items %}
-        <p>{{item.name}}</p>
+        <p>{{ item.name }}</p>
     {% endfor %}
     <div>
-        {{paginate.page_size}} Results <!-- Updated results number -->
-        {{paginate | default_pagination}}
+        {{ paginate.page_size }} Results <!-- Updated results number -->
+        {{ paginate | default_pagination }}
     </div>
 {% endproduct_search %}
 ```
@@ -89,7 +89,7 @@ Once the search has been executed, it can be helpful to get a reference to the p
 ##### syntax
 {% raw %}
 ```
-{{search.departure_date}}
+{{ search.departure_date }}
 ```
 {% endraw %}
 

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -49,22 +49,7 @@ The results of the search are paginated to speed up page load, you can define th
 
 You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
 
-You can assign the value of a liquid variable to `page_size`. You should update the `paginate.collection_size` to match.
-
-{% raw %}
-```liquid
-{% assign page_size = opt_selected_by_user %}
-{% product_search page_size: page_size, sort: 'departure_date_asc' %}
-  {% for item in result.items %}
-    <p>{{ item.name }}</p>
-  {% endfor %}
-  <div>
-    {{ paginate.page_size }} Results <!-- Updated results number -->
-    {{ paginate | default_pagination }}
-  </div>
-{% endproduct_search %}
-```
-{% endraw %}
+You can assign the value of a liquid variable to `page_size`.
 
 
 ## Parameters

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -18,6 +18,8 @@ The product search is executed using the [product_search tag]({% link docs/refer
 
 The product search will only return products will only return public, published products i.e. experiences and accommodations which are published and have not been marked as private under 'Manage product availability' in the product settings.
 
+> Note: Only one product_search tag should be used on a page to ensure expected results.
+
 {% raw %}
 ```liquid
 {% product_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -43,9 +43,26 @@ http://beyondadventures.com/search?search[name]=beyond&search[departure_date][gr
 > Note: Parameters passed through query params will overwrite any of those specified as an attribute on the product_search tag.
 
 ## Pagination
-The results of the search are paginated to speed up page load, you can define the number of results displayed per page using the [page_size]({% link docs/product_search/parameters.md %}#page_size)parameter.
+The results of the search are paginated to speed up page load, you can define the number of results displayed per page using the [page_size]({% link docs/product_search/parameters.md %}#page_size) parameter.
 
 You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
+
+You can assign the value of a liquid variable to `page_size`. You should update the `paginate.collection_size` to match.
+
+{% raw %}
+```liquid
+{% assign page_size = opt_selected_by_user %}
+{% product_search page_size: page_size, sort: 'departure_date_asc' %}
+    {% for item in result.items %}
+        <p>{{item.name}}</p>
+    {% endfor %}
+    <div>
+        {{paginate.page_size}} Results <!-- Updated results number -->
+        {{paginate | default_pagination}}
+    </div>
+{% endproduct_search %}
+```
+{% endraw %}
 
 
 ## Parameters

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -9,8 +9,9 @@ grand_parent: Docs
 Product search is based on parameters that determine which products are returned and in which order.
 
 ### active_promotion
-Accepts: `true` or `false`.<br>
-Passing `true` will return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
+Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+
+Passing `true` will only return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
 
 ##### as a search tag attribute
 {% raw %}
@@ -26,9 +27,12 @@ https://mysite.com/search?search[active_promotion]=true
 ```
 
 ### category
-Accepts a string and is case-sensitive.<br>
-Currently, the available Easol categories are: "Festival", "Wellness", "Adventure", "Food and Drink", "Active".<br>
-Will accept either a single category or an array.<br>
+Accepts a string and is case-sensitive. This can be passed as a liquid variable or explicitly.
+
+Currently, the available Easol categories are: "Festival", "Wellness", "Adventure", "Food and Drink", "Active".
+
+Will accept either a single category or an array. An array must be passed explicitly (not as a liquid variable).
+
 Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
 
 ##### as a search tag attribute
@@ -48,8 +52,10 @@ https://mysite.com/search?search[category]=active
 ```
 
 ### country
-Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names<br>
-Will accept either a single country or an array.<br>
+Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names. This can be passed as a liquid variable or explicitly.
+
+Will accept either a single country or an array. An array must be passed explicitly (not as a liquid variable).
+
 Will return products which match the country passed.
 
 ##### as a search tag attribute
@@ -69,13 +75,24 @@ https://mysite.com/search?search[country]=DE
 ```
 
 ### departure_date
-Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`.
+Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`. The date(s) can be passed as a liquid variable or explicitly.
+
 Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search departure_date: {greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
+{% product_search departure_date: { greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
+{% endproduct_search %}
+```
+{% endraw %}
+
+##### passing a liquid variable
+{% raw %}
+```
+{% assign latest_date = opt_selected_by_user %}
+
+{% product_search departure_date: { greater_or_equal_than: 'now', less_than: latest_date } %}
 {% endproduct_search %}
 ```
 {% endraw %}
@@ -86,7 +103,8 @@ https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-
 ```
 
 ### departure_month
-Accepts a month as either a 3-letter abbreviation, or the month number i.e. `Apr` or `4`.<br>
+Accepts a month as either a 3-letter abbreviation, or the month number i.e. `Apr` or `4`. This can be passed as a liquid variable or explicitly.
+
 Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the specified month, this may be across multiple years e.g. Apr 2023 and Apr 2024.
 
 ##### as a search tag attribute
@@ -107,8 +125,10 @@ https://mysite.com/search?search[departure_month]=4
 ```
 
 ### duration
-Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days.<br>
-Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.<br>
+Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days. The value(s) can be passed as a liquid variable or explicitly.
+
+Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.
+
 Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days or number of hours. i.e. `duration: {equal_to: 2}` will return experiences that have a duration of 2 hours or 1 night (2 days).
 
 ##### as a search tag attribute
@@ -125,7 +145,8 @@ https://mysite.com/search?search[duration][greater_than]=3&search[duration][less
 ```
 
 ### exclude_sold_out_products
-Accepts: `true` or `false`.<br>
+Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+
 Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
 
 ##### as a search tag attribute
@@ -142,7 +163,8 @@ https://mysite.com/search?search[exclude_sold_out_products]=true
 ```
 
 ### include_organisation_products
-Accepts: `true` or `false`.<br>
+Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+
 Passing `true` will include products from other companies which are linked in the same organisation.
 
 ##### as a search tag attribute
@@ -159,7 +181,8 @@ https://mysite.com/search?search[include_organisation_products]=true
 ```
 
 ### name
-Executes a partial search on the string passed in. Case insensitive.<br>
+Executes a partial search on the string passed in. Case insensitive. This can be passed as a liquid variable or explicitly.
+
 Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
 
 ##### as a search tag attribute
@@ -176,7 +199,8 @@ https://mysite.com/search?search[name]=my+experience
 ```
 
 ### series_id
-Accepts a series id.<br>
+Accepts a series id. This can be passed as a liquid variable or explicitly.
+
 Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
 
 ##### as a search tag attribute
@@ -193,8 +217,10 @@ https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
 ```
 
 ### subcategory
-Accepts a string and is case-sensitive.<br>
-Will accept either a single subcategory or an array.<br>
+Accepts a string and is case-sensitive. This can be passed as a liquid variable or explicitly.
+
+Will accept either a single subcategory or an array. An array must be passed explicitly (not as a liquid variable).
+
 Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
 
 ##### as a search tag attribute
@@ -214,7 +240,8 @@ https://mysite.com/search?search[subcategory]=wellness
 ```
 
 ### page_size
-Accepts a number.<br>
+Accepts a number. This can be passed as a liquid variable or explicitly.
+
 Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
 
 Page size cannot be passed as a query parameter.
@@ -228,7 +255,8 @@ Page size cannot be passed as a query parameter.
 {% endraw %}
 
 ### sort
-Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.<br>
+Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively. This can be passed as a liquid variable or explicitly.
+
 Will determine the order of the returned products.
 
 ##### as a search tag attribute

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -2,7 +2,6 @@
 layout: default
 title: Product search parameters
 parent: Product search
-grand_parent: Docs
 ---
 
 # Product search parameters

--- a/docs/reference/filters/group_by.md
+++ b/docs/reference/filters/group_by.md
@@ -15,10 +15,10 @@ This filter will group an array of items (such as events) by an attribute on the
   {% assign grouped_events = events | group_by: 'time' %}
   {% for group in grouped_events %}
     <article>
-      <h2>{{group.name}}</h2>
+      <h2>{{ group.name }}</h2>
 
       {% for event in group.items %}
-        <p>{{event.name}}</p>
+        <p>{{ event.name }}</p>
       {% endfor %}
     </article>
   {% endfor %}
@@ -53,10 +53,10 @@ This filter will group an array of items, in the same way as [group_by]({% link 
   {% assign grouped_events = events | group_by_exp: "event", "event.start_at | date: '%Y-%m-%d'" %}
   {% for group in grouped_events %}
     <article>
-      <h2>{{group.name}}</h2>
+      <h2>{{ group.name }}</h2>
 
       {% for event in group.items %}
-        <p>{{event.name}}</p>
+        <p>{{ event.name }}</p>
       {% endfor %}
     </article>
   {% endfor %}

--- a/docs/reference/filters/pagination.md
+++ b/docs/reference/filters/pagination.md
@@ -11,6 +11,6 @@ Provides complete pagination HTML for a supplied [Pagination]({%link docs/refere
 
 {% raw %}
 ```liquid
-{{paginate | default_pagination}}
+{{ paginate | default_pagination }}
 ```
 {% endraw %}

--- a/docs/reference/objects/footer/footer_item.md
+++ b/docs/reference/objects/footer/footer_item.md
@@ -14,7 +14,7 @@ The `Item` object can be accessed on the [`Footer`]({% link docs/reference/objec
 {% raw %}
 ```liquid
 {% for item in footer.items %}
-    <a href="{{item.path}}">{{item.label}}</a>
+    <a href="{{ item.path }}">{{ item.label }}</a>
 {% endfor %}
 ```
 {% endraw %}

--- a/docs/reference/objects/menu/menu_item.md
+++ b/docs/reference/objects/menu/menu_item.md
@@ -14,7 +14,7 @@ The `Item` object can be accessed on the [`Menu`]({% link docs/reference/objects
 {% raw %}
 ```liquid
 {% for item in menu.items %}
-    <a href="{{item.path}}">{{item.label}}</a>
+    <a href="{{ item.path }}">{{ item.label }}</a>
 {% endfor %}
 ```
 {% endraw %}

--- a/docs/reference/objects/modifier_selection_session.md
+++ b/docs/reference/objects/modifier_selection_session.md
@@ -91,10 +91,10 @@ Example usage:
 {% raw %}
 ```liquid
 {% for filter in item.selection_filters %}
-  <h3>{{filter.name}}</h3>
+  <h3>{{ filter.name }}</h3>
   <ul>
     {% for option in filter.options %}
-      <li {{option.attributes}}>{{option.name}}</li>
+      <li {{ option.attributes }}>{{ option.name }}</li>
     {% endfor %}
   </ul>
 {% endfor %}

--- a/docs/reference/objects/product/extra.md
+++ b/docs/reference/objects/product/extra.md
@@ -40,7 +40,7 @@ Deprecated, the deposit should be calculated in Liquid, using a mixture of the `
 {% raw %}
 ```liquid
 {% assign deposit_price = extra.price.fractional | times: extra.product.deposit.rate %}
-{{deposit_price | money}}
+{{ deposit_price | money }}
 ```
 {% endraw %}
 
@@ -112,7 +112,7 @@ The [price]({% link docs/reference/objects/product/price.md %}) of this extra in
 
 {% raw %}
 ```liquid
-{{extra.price.fractional | money}}
+{{ extra.price.fractional | money }}
 ```
 {% endraw %}
 
@@ -123,14 +123,14 @@ The behaviour of `extra.price` has been changed to enable math filters to be app
 **Deprecated method**
 {% raw %}
 ```
-<p>{{extra.price}}</p>
+<p>{{ extra.price }}</p>
 ```
 {% endraw %}
 
 **Updated method**
 {% raw %}
 ```
-<p>{{extra.price | money}} Per Person</p>
+<p>{{ extra.price | money }} Per Person</p>
 ```
 {% endraw %}
 
@@ -151,8 +151,8 @@ An array containing the single [price]({% link docs/reference/objects/product/pr
 
 {% raw %}
 ```liquid
-{{assign price = extra.prices | first}}
-{{price.fractional | money}}
+{{ assign price = extra.prices | first }}
+{{ price.fractional | money }}
 ```
 {% endraw %}
 

--- a/docs/reference/objects/product/modifier.md
+++ b/docs/reference/objects/product/modifier.md
@@ -31,7 +31,7 @@ A string of HTML attributes to be used on a checkbox for the modifier.
 
 {% raw %}
 ```
-<input {{modifier.checkbox_attributes}}>
+<input {{ modifier.checkbox_attributes }}>
 ```
 {% endraw %}
 
@@ -53,7 +53,7 @@ An array of custom properties defined on this modifier. Each custom field has tw
 ```liquid
 <ul>
   {% for field in modifier.custom_fields %}
-    <li>{{field.key}}: {{field.value}}</li>
+    <li>{{ field.key }}: {{ field.value }}</li>
   {% endfor %}
 </ul>
 ```
@@ -68,7 +68,7 @@ An object containing the custom properties for the modifier.
 
 {% raw %}
 ```
-{{modifier.custom_fields_data.category}}
+{{ modifier.custom_fields_data.category }}
 ```
 {% endraw %}
 
@@ -91,7 +91,7 @@ It can be used in the Liquid markup like this:
 
 {% raw %}
 ```
-<input {{modifier.checkbox_attributes}} {{modifier.data_attributes}}>
+<input {{ modifier.checkbox_attributes }} {{ modifier.data_attributes }}>
 ```
 {% endraw %}
 
@@ -151,7 +151,7 @@ A string of HTML attributes to be used on an input label for the modifier.
 
 {% raw %}
 ```
-<label {{modifier.label_attributes}}>{{modifier.name}}</label>
+<label {{ modifier.label_attributes }}>{{ modifier.name }}</label>
 ```
 {% endraw %}
 

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -50,7 +50,7 @@ Deprecated, the deposit should be calculated in Liquid, using a mixture of the `
 {% raw %}
 ```liquid
 {% assign deposit_price = variant.price.fractional | times: variant.product.deposit.rate %}
-{{deposit_price | money}}
+{{ deposit_price | money }}
 ```
 {% endraw %}
 
@@ -72,7 +72,7 @@ Deprecated, the display amount should be obtained using the `variant.price` with
 
 {% raw %}
 ```liquid
-{{variant.price | money}}
+{{ variant.price | money }}
 ```
 {% endraw %}
 
@@ -161,7 +161,7 @@ The [price]({% link docs/reference/objects/product/price.md %}) of this variant 
 
 {% raw %}
 ```liquid
-{{variant.price.fractional | money}}
+{{ variant.price.fractional | money }}
 ```
 {% endraw %}
 
@@ -172,14 +172,14 @@ The behaviour of `variant.price` has been changed to enable math filters to be a
 **Deprecated method**
 {% raw %}
 ```
-<p>{{variant.price}}</p>
+<p>{{ variant.price }}</p>
 ```
 {% endraw %}
 
 **Updated method**
 {% raw %}
 ```
-<p>{{variant.price | money}} Per Person</p>
+<p>{{ variant.price | money }} Per Person</p>
 ```
 {% endraw %}
 
@@ -192,8 +192,8 @@ An array containing the [prices]({% link docs/reference/objects/product/price.md
 
 {% raw %}
 ```liquid
-{{assign price = variant.prices | first}}
-{{price.fractional | money}}
+{{ assign price = variant.prices | first }}
+{{ price.fractional | money }}
 ```
 {% endraw %}
 

--- a/docs/reference/tags/accommodation_availability_tag/index.md
+++ b/docs/reference/tags/accommodation_availability_tag/index.md
@@ -15,7 +15,7 @@ The `accommodation_availability` tag returns an array of [Availability Day]({% l
 ```liquid
 {% accommodation_availability variant %}
   {% for day in result.days %}
-       <time data-available="{{day.available}}" datetime="{{day.date}}">{{day.date | date:"%b %d, %y"}}</time>
+       <time data-available="{{ day.available }}" datetime="{{ day.date }}">{{ day.date | date:"%b %d, %y" }}</time>
   {% endfor %}
 {% endaccommodation_availability %}
 ```

--- a/docs/reference/tags/cache_tag/index.md
+++ b/docs/reference/tags/cache_tag/index.md
@@ -36,8 +36,8 @@ The following example sets an expiry time of 5 minutes: `expires_in: 300`.
 {% raw %}
 ```liquid
 {% cache variant, variant.product, expires_in: 300 %}
-   {{product.name}}
-   {{variant.min_price}}
+   {{ product.name }}
+   {{ variant.min_price }}
  {% endcache %}
 ```
 {% endraw %}

--- a/docs/reference/tags/product_search/index.md
+++ b/docs/reference/tags/product_search/index.md
@@ -16,11 +16,11 @@ The Product Search Tag executes a search on the company's products, it then pagi
 ```liquid
 {% product_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}
     {% for item in result.items %}
-        <p>{{item.name}}</p>
+        <p>{{ item.name }}</p>
     {% endfor %}
     <div>
-        {{paginate.collection_size}} Results
-        {{paginate | default_pagination}}
+        {{ paginate.collection_size }} Results
+        {{ paginate | default_pagination }}
     </div>
 {% endproduct_search %}
 ```
@@ -137,11 +137,11 @@ These should be passed as a string describing the dimension to sort on and the d
 ```liquid
 {% product_search name: 'Beyond', sort: 'name_asc' %}
     {% for item in result.items %}
-        <p>{{item.name}}</p>
+        <p>{{ item.name }}</p>
     {% endfor %}
     <div>
-        {{paginate.collection_size}} Results
-        {{paginate | default_pagination}}
+        {{ paginate.collection_size }} Results
+        {{ paginate | default_pagination }}
     </div>
 {% endproduct_search %}
 ```
@@ -158,10 +158,10 @@ For that, we can use the `Search` object, which exposes all of the params listed
 
 {% raw %}
 ```liquid
-{{search.departure_date}}
+{{ search.departure_date }}
 
 or
 
-{{search["departure_date"]}}
+{{ search["departure_date"] }}
 ```
 {% endraw %}

--- a/docs/site_navigation/footer.md
+++ b/docs/site_navigation/footer.md
@@ -25,17 +25,17 @@ supports_open_new_tab: true
 ```liquid
 {% unless footer.items == blank %}
     {% for item in footer.items %}
-    <a href="{% if item.url != '' %}{{item.url}}{% else %}javascript:void(0);{% endif %}"
+    <a href="{% if item.url != '' %}{{ item.url }}{% else %}javascript:void(0);{% endif %}"
         {% if item.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
-        {{item.label}}
+        {{ item.label }}
     </a>
         {% if item.items.size > 0 %}
         <ul>
             {% for nested_item in item.items %}
             <li>
-                <a href="{% if nested_item.url != '' %}{{nested_item.url}}{% else %}javascript:void(0);{% endif %}" 
+                <a href="{% if nested_item.url != '' %}{{ nested_item.url }}{% else %}javascript:void(0);{% endif %}" 
                 {% if nested_item.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
-                    {{nested_item.label}}
+                    {{ nested_item.label }}
                 </a>
             </li>
             {% endfor %}
@@ -63,7 +63,7 @@ attributes:
 ```liquid
 <footer>
     {% if footer.brand_slogan %}
-    <h6>{{footer.brand_slogan}}</h6>
+    <h6>{{ footer.brand_slogan }}</h6>
     {% endif %}
 </footer>
 ```

--- a/docs/site_navigation/header.md
+++ b/docs/site_navigation/header.md
@@ -26,17 +26,17 @@ supports_open_new_tab: true
 ```
 ```liquid
 {% for item in menu.items %}
-    <a href="{% if item.url != '' %}{{item.url}}{% else %}javascript:void(0);{% endif %}"
+    <a href="{% if item.url != '' %}{{ item.url }}{% else %}javascript:void(0);{% endif %}"
     {% if item.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
-        {{item.label}}
+        {{ item.label }}
     </a>
     {% if item.items.size > 0 %}
         <ul>
         {% for nested_item in item.items %}
             <li>
-                <a href="{% if nested_item.url != '' %}{{nested_item.url}}{% else %}javascript:void(0);{% endif %}" 
+                <a href="{% if nested_item.url != '' %}{{ nested_item.url }}{% else %}javascript:void(0);{% endif %}" 
                 {% if nested_item.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
-                    {{nested_item.label}}
+                    {{ nested_item.label }}
                 </a>
             </li>
         {% endfor %}
@@ -63,7 +63,7 @@ attributes:
 ```liquid
 <header>
     {% if menu.festival_announcement %}
-        <h6>{{menu.festival_announcement}}</h6>
+        <h6>{{ menu.festival_announcement }}</h6>
     {% endif %}
 </header>
 ```

--- a/docs/theme_architecture/blocks/index.md
+++ b/docs/theme_architecture/blocks/index.md
@@ -32,8 +32,8 @@ attributes:
         group: design
         hint: Recommended image size 1920px by 600px
 ---
-<h1>{{heading}}</h1>
-{{text}}
-<img src="{{image.xxlarge_url}}">
+<h1>{{ heading }}</h1>
+{{ text }}
+<img src="{{ image.xxlarge_url }}">
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/index.md
+++ b/docs/theme_architecture/blocks/schema/variables/index.md
@@ -68,7 +68,7 @@ gallery:
 ---
 
 {% for image in gallery %}
-    <img src="{{image.url}}"> 
+    <img src="{{ image.url }}"> 
 {% endfor %}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/boolean.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/boolean.md
@@ -18,6 +18,6 @@ my_variable:
     default: true
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/color.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/color.md
@@ -19,7 +19,7 @@ my_variable:
         palette: body-color
 ---
 
-{{my_variable.rgba}}
+{{ my_variable.rgba }}
 
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/custom_types.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/custom_types.md
@@ -52,7 +52,7 @@ my_variable:
     type: my_custom_type
 ---
 
-<a class="{{my_variable.style}}" href="{{my_variable.link.url}}">{{my_variable.label}}</a>
+<a class="{{ my_variable.style }}" href="{{ my_variable.link.url }}">{{ my_variable.label }}</a>
 ```
 {% endraw %}
 
@@ -70,7 +70,7 @@ my_variable:
         style: btn-primary
 ---
 
-<a class="{{my_variable.style}}" href="{{my_variable.link.url}}">{{my_variable.label}}</a>
+<a class="{{ my_variable.style }}" href="{{ my_variable.link.url }}">{{ my_variable.label }}</a>
 ```
 {% endraw %}
 
@@ -91,7 +91,7 @@ buttons:
           style: btn-secondary
 ---
 {% for button in buttons %}
-    <a class="{{button.style}}" href="{{button.link.url}}">{{button.label}}</a>
+    <a class="{{ button.style }}" href="{{ button.link.url }}">{{ button.label }}</a>
 {% endfor %}    
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/image.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/image.md
@@ -18,7 +18,7 @@ my_variable:
         url: https://my-image.jpg
 ---
 
-<img src="{{my_variable.url}}">
+<img src="{{ my_variable.url }}">
 
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/link.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/link.md
@@ -19,7 +19,7 @@ my_variable:
         url: https://easol.com
 ---
 
-<a href="{{my_variable.url}}"
+<a href="{{ my_variable.url }}"
     {% if my_variable.new_tab %}target="_blank" rel="noopener noreferrer"{% endif %}>
     Click here
 </a>

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/number.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/number.md
@@ -17,6 +17,6 @@ my_variable:
     default: 1
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/page.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/page.md
@@ -19,6 +19,6 @@ my_variable:
     default: random
 ---
 
-{{my_variable.url}}
+{{ my_variable.url }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/post.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/post.md
@@ -19,6 +19,6 @@ my_variable:
     default: random
 ---
 
-{{my_variable.url}}
+{{ my_variable.url }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/product.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/product.md
@@ -19,6 +19,6 @@ my_variable:
     default: random
 ---
 
-{{my_variable.name}}
+{{ my_variable.name }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/radio.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/radio.md
@@ -23,6 +23,6 @@ my_variable:
           value: opt_2
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/range.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/range.md
@@ -23,6 +23,6 @@ my_variable:
     default: 50
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/select.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/select.md
@@ -23,6 +23,6 @@ my_variable:
           value: opt_2
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/string.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/string.md
@@ -17,6 +17,6 @@ my_variable:
     default: hello world
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/text.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/text.md
@@ -17,6 +17,6 @@ my_variable:
     default: <p>hello world</p>
 ---
 
-{{my_variable}}
+{{ my_variable }}
 ```
 {% endraw %}

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/variant.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/variant.md
@@ -20,6 +20,6 @@ my_variable:
     default: random
 ---
 
-{{my_variable.name}}
+{{ my_variable.name }}
 ```
 {% endraw %}


### PR DESCRIPTION
Did a little refactoring for liquid conventions whilst I was here.
I've chosen not to make any addition to the reference docs for [product_search](docs/reference/tags/product_search/index.md) or [pagination filter](docs/reference/filters/pagination.md) - thoughts?

Please read and review [docs/product_search/index.md](docs/product_search/index.md) and [docs/product_search/parameters.md](docs/product_search/parameters.md)
Let me know if the repeated phrases make sense or suggest improved wording. 
Let me know if you think it's better to give a blanket summary about how attributes can be passed as liquid variables unless using array. My reasoning for repeating next to each parameter is that for me personally reading docs I would end up in the e.g. 'duration parameter' section more often than I would ever be reading the summary overview of parameters generally. 