### PR TITLE
feat: enable creators to select redirect url

### DIFF
--- a/docs/site_navigation/redirects.md
+++ b/docs/site_navigation/redirects.md
@@ -40,19 +40,27 @@ Redirecting the homepage requires a different approach. To do this, follow these
 1. Create a new blank page 
 1. Add a custom Liquid/CSS block to the page
 1. Add the following code into the new block
-```
-<script>
-    window.location.replace("NEWLOCATION");
-</script>
-```
 
-For example:
+{% raw %}
+```liquid
+---
+redirect_link:
+  type: link
+  label: Page to redirect to
+---
+
+{% if redirect_link %}
+  <script>
+    const hostname = window.location.hostname
+    if(!hostname.includes('myeasol')) {
+      window.location.replace('{{ redirect_link.url }}')
+    }
+  </script>
+{% endif %}
 ```
-<script>
-    window.location.replace("https://www.coolcompany.com/products/very-cool-experience");
-</script>
-```
+{% endraw %}
+
 {:style="counter-reset:none"}
 1. Set the new page as the site homepage
 
-You can redirect the homepage to a product or site page as long as it's published. Make sure you use the full published URL of the product or site page in your redirect code.
+The creator will be able to select which page to redirect to by setting it via the `redirect_link` field.


### PR DESCRIPTION
Currently creators are unable to set the homepage of their site as a template page e.g. product page, and they are unable to redirect the homepage to another page. As a workaround we use a location.replace to force the browser to load their chosen page.

Previously adding the script would create the redirect but break the site preview, therefore requiring further support from frontend to make any updates. By introducing a check that the current hostname does not contain myeasol we can enable creators to edit the block in the site admin and update the page they are redirecting to without further support from frontend enginnering.