### PR TITLE
docs: adding info about date formatting to internationalisation page

### DIFF
--- a/docs/internationalisation/index.md
+++ b/docs/internationalisation/index.md
@@ -8,3 +8,5 @@ nav_order: 13
 # Internationalisation
 
 Easol powers Creators globally. To support this, Easol enables Creators to sell in [multiple currencies]({% link docs/pricing_and_payments/currency_switcher.md %}) and has [built-in translation]({% link docs/internationalisation/localisation.md %}) on checkout pages.
+
+Dates throughout creator sites are formatted by the [DatesHelper](https://github.com/easolhq/easol/blob/main/spec/helpers/dates_helper_spec.rb), based on the the users browser language.


### PR DESCRIPTION
Minor change which adds a sentance to the docs about dates being formatting based on the users browser locale, throughout creator sites.