### PR TITLE
docs: removing link to private repo and adding date internationalisation example

### DIFF
--- a/docs/internationalisation/index.md
+++ b/docs/internationalisation/index.md
@@ -9,4 +9,4 @@ nav_order: 13
 
 Easol powers Creators globally. To support this, Easol enables Creators to sell in [multiple currencies]({% link docs/pricing_and_payments/currency_switcher.md %}) and has [built-in translation]({% link docs/internationalisation/localisation.md %}) on checkout pages.
 
-Dates throughout creator sites are formatted by the [DatesHelper](https://github.com/easolhq/easol/blob/main/spec/helpers/dates_helper_spec.rb), based on the the users browser language.
+Dates throughout creator sites are formatted based on the the users browser language. For example, when set to `en-US` the day will succeed the month e.g. `January 1 2023`, rather than `1 January 2023`.


### PR DESCRIPTION
Follow up to: https://github.com/easolhq/easolhq.github.io/pull/105

Removes the link to the repo, as it's private and adds an example instead.