### PR TITLE
Update docs to reflect inclusion of  data-action attribute

### DIFF
--- a/docs/reference/tags/form_tags/clear_cart/index.md
+++ b/docs/reference/tags/form_tags/clear_cart/index.md
@@ -21,7 +21,7 @@ The `clear_cart` tag renders a button that clears the customer's cart.
 ##### output
 {% raw %}
 ```html
-<form action="/sites/cart" accept-charset="UTF-8" method="post">
+<form action="/sites/cart" data-form-action="clear_cart" accept-charset="UTF-8" method="post">
     <input type="hidden" name="_method" value="delete" autocomplete="off">
     <input type="hidden" name="return_to" id="return_to" value="https://www.creator-website.com/book-tickets" autocomplete="off">
     <input type="submit" value="Clear">

--- a/docs/reference/tags/form_tags/create_line_item/create_line_item.md
+++ b/docs/reference/tags/form_tags/create_line_item/create_line_item.md
@@ -22,7 +22,7 @@ Extra HTML input tags can be used to add item quantity, modifiers, adult count o
 ##### output
 {% raw %}
 ```html
-<form action="/sites/line-items" accept-charset="UTF-8" method="post">
+<form action="/sites/line-items" data-form-action="create_line_item" accept-charset="UTF-8" method="post">
     <input type="hidden" name="return_to" id="return_to" value="/admin/site_builder/sites/c94b650e/previews/book-tickets" autocomplete="off">
     <input type="hidden" name="items[][variant_id]" value="BAh7CEkiCGdpZAY6Bk....">
 </form>

--- a/docs/reference/tags/form_tags/item_selections/item_selections.md
+++ b/docs/reference/tags/form_tags/item_selections/item_selections.md
@@ -21,7 +21,7 @@ The `item_selections` tag returns an object which can be used as a wrapper to di
 ##### output
 {% raw %}
 ```html
-<form action="/items/example/path/selections" accept-charset="UTF-8" method="post">
+<form action="/items/example/path/selections" data-form-action="item_selections" accept-charset="UTF-8" method="post">
     <input type="hidden" name="_method" value="put" autocomplete="off">
     <input type="submit" id="save" value="Confirm my selections" disabled="">
 </form>

--- a/docs/reference/tags/form_tags/remove_line_item/index.md
+++ b/docs/reference/tags/form_tags/remove_line_item/index.md
@@ -23,9 +23,10 @@ The tag can be used with a single line item or when iterating over a collection 
 ##### output
 {% raw %}
 ```html
-<form action="/sites/line-items" accept-charset="UTF-8" method="post"><input type="hidden" name="_method" value="delete" autocomplete="off">
-    <input name="items[]" value="1354af560050dec9a1611f7ac473d2e4" type="hidden">
-    <input type="submit" value="Remove">
+<form action="/sites/line-items" data-form-action="remove_line_item" accept-charset="UTF-8" method="post">
+  <input type="hidden" name="_method" value="delete" autocomplete="off">
+  <input name="items[]" value="1354af560050dec9a1611f7ac473d2e4" type="hidden">
+  <input type="submit" value="Remove">
 </form>
 ```
 {% endraw %}


### PR DESCRIPTION
This is so the frontend team can more easily target these forms. Suggestion to update docs further with examples of how we intend to use this targeting