### PR TITLE
Update ActiveSupport to v7.0.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,11 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.6.1)
+    activesupport (7.0.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
     addressable (2.8.1)
       public_suffix (>= 2.0.2, < 6.0)
     coffee-script (2.4.1)
@@ -258,17 +257,15 @@ GEM
       unf (~> 0.1.4)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.10)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
     webrick (1.8.1)
-    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
💁 These changes bump `tzinfo` to ~ v2.x, which in turn allows `activesupport` to be upgraded to mitigate the following security vulnerability:

> There is a possible regular expression based DoS vulnerability in
> Active Support. This vulnerability has been assigned the CVE
> identifier CVE-2023-22796.
>
> Versions Affected: All
> Not affected: None
> Fixed Versions: 5.2.8.15 (Rails LTS), 6.1.7.1, 7.0.4.1

https://github.com/advisories/GHSA-j6gc-792m-qgm2