### PR TITLE
Document new `only` option for `product` type

### DIFF
--- a/docs/theme_architecture/blocks/schema/variables/variable_types/product.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/product.md
@@ -7,8 +7,12 @@ parent: Variable types
 # Product
 
 Renders a select input from which a Creator can select a product.
+
 Returns a [Product]({% link docs/reference/objects/product/index.md %}) object.
-The product variable only accepts a default of `random` which will select a random product from the Creator's published products.
+
+- Accepts a `default` of `random` which will select a random product from the Creator's published products.
+- Has an optional `only` list, which supports restricting the product types. The allowed values are `experiences` and `accommodations`. If `only` is missing, it defaults to all types.
+  `random` defaults will comply with these restrictions.
 
 ##### syntax
 {% raw %}
@@ -17,6 +21,9 @@ The product variable only accepts a default of `random` which will select a rand
 my_variable:
     type: product
     default: random
+    only:
+        - experiences
+        - accommodations
 ---
 
 {{ my_variable.name }}


### PR DESCRIPTION
Documents the new restriction option on the product dropdown.

<img width="961" alt="image" src="https://user-images.githubusercontent.com/1526295/225634965-09050e5b-32ac-4e31-8673-4ed718f64a67.png">



#### Dependencies
To be merged after:
- https://github.com/easolhq/easol/pull/8692 (which implements the changes).
