### PR TITLE
Document new `only_from` option for `variant` type

### DIFF
--- a/docs/theme_architecture/blocks/schema/variables/variable_types/variant.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/variant.md
@@ -7,9 +7,13 @@ has_children: false
 
 # Variant
 
-Renders a select input from which a Creator can select a product variant.
+Renders two select inputs from which a Creator can select a product and then a variant.
+
 Returns a [Variant]({% link docs/reference/objects/product/variant/index.md %}) object.
-The variant variable only accepts a default of `random` which will select a random variant from the Creator's published products.
+
+- Accepts a `default` of `random` which will select a random variant from the Creator's published products.
+- Has an optional `only_from` list, which supports restricting the product types. The allowed values are `experiences` and `accommodations`. If `only_from` is missing, it defaults to all types.
+  `random` defaults will comply with these restrictions.
 
 ##### syntax
 {% raw %}
@@ -18,6 +22,9 @@ The variant variable only accepts a default of `random` which will select a rand
 my_variable:
     type: variant
     default: random
+    only_from:
+        - experiences
+        - accommodations
 ---
 
 {{ my_variable.name }}


### PR DESCRIPTION
Documents the new restriction option on the product dropdown under `variant` attributes.

<img width="961" alt="image" src="https://user-images.githubusercontent.com/1526295/226337012-84549900-53cf-4cce-868a-cb4dabf32821.png">


### Dependencies

To be merged after:

- https://github.com/easolhq/easol/pull/8760

Related to:

- #113