### PR TITLE
Refactor some things

### DIFF
--- a/docs/filters/index.md
+++ b/docs/filters/index.md
@@ -7,7 +7,7 @@ nav_order: 10
 
 # Filters
 
-Liquid filters modify Liquid output. They can be applied to any liquid output and may accept parameters.
+Liquid filters modify Liquid output. They can be applied to any Liquid output and may accept parameters.
 
 {% raw %}
 ```liquid

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -49,7 +49,7 @@ The results of the search are paginated to speed up page load, you can define th
 
 You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
 
-You can assign the value of a liquid variable to `page_size`.
+You can assign the value of a Liquid variable to `page_size`.
 
 
 ## Parameters

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -8,7 +8,7 @@ parent: Product search
 Product search is based on parameters that determine which products are returned and in which order.
 
 ### active_promotion
-Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
 
 Passing `true` will only return items with a currently active [promotion]({% link docs/reference/objects/product/promotion.md %}#promotionactive).
 
@@ -26,11 +26,11 @@ https://mysite.com/search?search[active_promotion]=true
 ```
 
 ### category
-Accepts a string and is case-sensitive. This can be passed as a liquid variable or explicitly.
+Accepts a string and is case-sensitive. This can be passed as a Liquid variable or explicitly.
 
 Currently, the available Easol categories are: "Festival", "Wellness", "Adventure", "Food and Drink", "Active".
 
-Will accept either a single category or an array. An array must be passed explicitly (not as a liquid variable).
+Will accept either a single category or an array. An array must be passed explicitly (not as a Liquid variable).
 
 Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
 
@@ -51,9 +51,9 @@ https://mysite.com/search?search[category]=active
 ```
 
 ### country
-Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names. This can be passed as a liquid variable or explicitly.
+Accepts any of the Easol predefined [countries]({% link docs/reference/objects/product/index.md %}#productcountry) as either Country Codes or Country Names. This can be passed as a Liquid variable or explicitly.
 
-Will accept either a single country or an array. An array must be passed explicitly (not as a liquid variable).
+Will accept either a single country or an array. An array must be passed explicitly (not as a Liquid variable).
 
 Will return products which match the country passed.
 
@@ -74,7 +74,7 @@ https://mysite.com/search?search[country]=DE
 ```
 
 ### departure_date
-Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`. The date(s) can be passed as a liquid variable or explicitly.
+Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`. The date(s) can be passed as a Liquid variable or explicitly.
 
 Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
 
@@ -86,7 +86,7 @@ Will return experiences which depart within the [departure date]({% link docs/re
 ```
 {% endraw %}
 
-##### passing a liquid variable
+##### passing a Liquid variable
 {% raw %}
 ```
 {% assign latest_date = opt_selected_by_user %}
@@ -102,7 +102,7 @@ https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-
 ```
 
 ### departure_month
-Accepts a month as either a 3-letter abbreviation, or the month number i.e. `Apr` or `4`. This can be passed as a liquid variable or explicitly.
+Accepts a month as either a 3-letter abbreviation, or the month number i.e. `Apr` or `4`. This can be passed as a Liquid variable or explicitly.
 
 Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the specified month, this may be across multiple years e.g. Apr 2023 and Apr 2024.
 
@@ -124,7 +124,7 @@ https://mysite.com/search?search[departure_month]=4
 ```
 
 ### duration
-Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days. The value(s) can be passed as a liquid variable or explicitly.
+Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days. The value(s) can be passed as a Liquid variable or explicitly.
 
 Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.
 
@@ -144,7 +144,7 @@ https://mysite.com/search?search[duration][greater_than]=3&search[duration][less
 ```
 
 ### exclude_sold_out_products
-Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
 
 Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
 
@@ -162,7 +162,7 @@ https://mysite.com/search?search[exclude_sold_out_products]=true
 ```
 
 ### include_organisation_products
-Accepts: `true` or `false`. This can be passed as a liquid variable or explicitly.
+Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
 
 Passing `true` will include products from other companies which are linked in the same organisation.
 
@@ -180,7 +180,7 @@ https://mysite.com/search?search[include_organisation_products]=true
 ```
 
 ### name
-Executes a partial search on the string passed in. Case insensitive. This can be passed as a liquid variable or explicitly.
+Executes a partial search on the string passed in. Case insensitive. This can be passed as a Liquid variable or explicitly.
 
 Will return any products whose [name]({% link docs/reference/objects/product/index.md %}#productname) matches the argument.
 
@@ -198,7 +198,7 @@ https://mysite.com/search?search[name]=my+experience
 ```
 
 ### series_id
-Accepts a series id. This can be passed as a liquid variable or explicitly.
+Accepts a series id. This can be passed as a Liquid variable or explicitly.
 
 Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
 
@@ -216,9 +216,9 @@ https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
 ```
 
 ### subcategory
-Accepts a string and is case-sensitive. This can be passed as a liquid variable or explicitly.
+Accepts a string and is case-sensitive. This can be passed as a Liquid variable or explicitly.
 
-Will accept either a single subcategory or an array. An array must be passed explicitly (not as a liquid variable).
+Will accept either a single subcategory or an array. An array must be passed explicitly (not as a Liquid variable).
 
 Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
 
@@ -239,7 +239,7 @@ https://mysite.com/search?search[subcategory]=wellness
 ```
 
 ### page_size
-Accepts a number. This can be passed as a liquid variable or explicitly.
+Accepts a number. This can be passed as a Liquid variable or explicitly.
 
 Will determine how many results are shown per page. If this is not included it will default to 12 results per page.
 
@@ -254,7 +254,7 @@ Page size cannot be passed as a query parameter.
 {% endraw %}
 
 ### sort
-Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively. This can be passed as a liquid variable or explicitly.
+Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively. This can be passed as a Liquid variable or explicitly.
 
 Will determine the order of the returned products.
 

--- a/docs/reference/objects/blog_post.md
+++ b/docs/reference/objects/blog_post.md
@@ -51,7 +51,7 @@ The previous blog post.
 timestamp
 {: .label .fs-1 }
 
-The date the blog post was published. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date the blog post was published. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `blog_post.tagline`
 {: .d-inline-block }

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -60,7 +60,7 @@ e.g `15 - 20 November 2019` or `15 November 2019`.
 timestamp
 {: .label .fs-1 }
 
-If the product has fixed dates this returns the start date of the event as a timestamp, this can then be used in conjunction with liquids [built-in filters](https://shopify.github.io/liquid/filters/date/).
+If the product has fixed dates this returns the start date of the event as a timestamp, this can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `product.deposit`
 {: .d-inline-block }

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -141,7 +141,7 @@ An array of [Image]({% link docs/reference/objects/image.md %}) objects for the 
 boolean
 {: .label .fs-1 }
 
-Returns `true` if the product has infinite stock.
+Returns `true` if any variant on the product has infinite stock.
 
 ## `product.hero_image`
 {: .d-inline-block }

--- a/docs/reference/objects/product/promotion.md
+++ b/docs/reference/objects/product/promotion.md
@@ -70,7 +70,7 @@ It will return `nil` if the promotion is a monetary amount.
 timestamp
 {: .label .fs-1 }
 
-Returns the date the promotion will end as a timestamp, this can then be used in conjunction with liquids[ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+Returns the date the promotion will end as a timestamp, this can then be used in conjunction with liquids [built-in filters](https://shopify.github.io/liquid/filters/date/).
 It will return `nil` if the promotion doesn't have an end date.
 
 ## `promotion.name`
@@ -85,7 +85,7 @@ Returns the name of the promotion.
 timestamp
 {: .label .fs-1 }
 
-Returns the date the promotion will start as a timestamp, this can then be used in conjunction with liquids[ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+Returns the date the promotion will start as a timestamp, this can then be used in conjunction with liquids [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `promotion.tagline`
 {: .d-inline-block }

--- a/docs/reference/objects/product/transfer.md
+++ b/docs/reference/objects/product/transfer.md
@@ -19,28 +19,28 @@ deprecated
 timestamp
 {: .label .fs-1 }
 
-The date this transfer departs as a timestamp. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date this transfer departs as a timestamp. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `transfer.arrives_on`
 {: .d-inline-block }
 timestamp
 {: .label .fs-1 }
 
-The date this transfer arrives as a timestamp. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date this transfer arrives as a timestamp. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `transfer.return_departs_on`
 {: .d-inline-block }
 timestamp
 {: .label .fs-1 }
 
-The date this transfer departs on the return leg of the journey, as a timestamp. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date this transfer departs on the return leg of the journey, as a timestamp. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `transfer.return_arrives_on`
 {: .d-inline-block }
 timestamp
 {: .label .fs-1 }
 
-The date this transfer arrives on the return leg of the journey, as a timestamp. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date this transfer arrives on the return leg of the journey, as a timestamp. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `transfer.departure`
 {: .d-inline-block }

--- a/docs/reference/objects/product/useful_info.md
+++ b/docs/reference/objects/product/useful_info.md
@@ -17,14 +17,14 @@ object
 timestamp
 {: .label .fs-1 }
 
-The check-in time of the event as a timestamp, this can then be used in conjunction with liquids[ built-in filters ](https://shopify.github.io/liquid/filters/date/)
+The check-in time of the event as a timestamp, this can then be used in conjunction with liquids[built-in filters](https://shopify.github.io/liquid/filters/date/)
 
 ## `useful_info.check_out`
 {: .d-inline-block }
 timestamp
 {: .label .fs-1 }
 
-The check-out time of the event as a timestamp, this can then be used in conjunction with liquids[ built-in filters ](https://shopify.github.io/liquid/filters/date/)
+The check-out time of the event as a timestamp, this can then be used in conjunction with liquids[built-in filters](https://shopify.github.io/liquid/filters/date/)
 
 ## `useful_info.other_information`
 {: .d-inline-block }

--- a/docs/reference/objects/product/variant/accommodation_variant/availabilty_day.md
+++ b/docs/reference/objects/product/variant/accommodation_variant/availabilty_day.md
@@ -24,7 +24,7 @@ If the accommodation is marked as available for the date.
 timestamp
 {: .label .fs-1 }
 
-The date as a timestamp. This can then be used in conjunction with Liquid's [ built-in filters ](https://shopify.github.io/liquid/filters/date/).
+The date as a timestamp. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
 ## `availability_day.prices`
 {: .d-inline-block }

--- a/docs/theme_architecture/blocks/index.md
+++ b/docs/theme_architecture/blocks/index.md
@@ -8,7 +8,7 @@ nav_order: 5
 
 # Blocks
 
-Blocks are the main building components of sites, allowing Creators to easily build their site pages. These are defined as liquid in a `block.html` file within a folder per block and are all listed in an [index.json]({% link docs/theme_architecture/blocks/index_json.md %}) file.
+Blocks are the main building components of sites, allowing Creators to easily build their site pages. These are defined as Liquid in a `block.html` file within a folder per block and are all listed in an [index.json]({% link docs/theme_architecture/blocks/index_json.md %}) file.
 
 Blocks are comprised of a [block schema]({% link docs/theme_architecture/blocks/schema/index.md %}) and the block html. You can also include styles and scripts within the block, as required.
 

--- a/docs/theme_architecture/blocks/schema/variables/index.md
+++ b/docs/theme_architecture/blocks/schema/variables/index.md
@@ -10,7 +10,7 @@ nav_order: 1
 
 Variables define the fields a Creator can use to customise the content and layout of a block. Variables are defined within the blocks using YAML front matter.
 
-Variables consist of a `key`, which is used to access the variable within the block liquid code, and attributes which define the variable.
+Variables consist of a `key`, which is used to access the variable within the block Liquid code, and attributes which define the variable.
 
 ##### Example
 {% raw %}


### PR DESCRIPTION
About to update the docs for multi-date, tidying some things before I start:

- Remove spacing inside links, otherwise create's this:
<img width="182" alt="Screenshot 2023-04-03 at 11 55 54" src="https://user-images.githubusercontent.com/78875971/229557342-1551d95b-2dc5-47ff-bcf7-a17958834876.png">

- We already have some capitalised `Liquid`s this standardises it.

-  Missing apostrophes

- Clarify behaviour of `product.has_infinite_stock` I was drafting some methods for dates and tried to write this, realised the description here isn't as clear as it could be.