### PR TITLE
Update docs to reflect current implementation

### DIFF
--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -361,8 +361,11 @@ An array of the product's [variants]({% link docs/reference/objects/product/vari
 {: .d-inline-block }
 array of [modifier]({% link docs/reference/objects/product/modifier.md %})s
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
-An array of all the [modifiers]({% link docs/reference/objects/product/modifier.md %}) associated with this product through its variants.
+An array of [modifiers]({% link docs/reference/objects/product/modifier.md %}) associated with this product.
+Deprecated, modifiers should be accessed through each [variant modifier group]({% link docs/reference/objects/product/variant/index.md %}#variantmodifier_groups) or [extra modifier group]({% link docs/reference/objects/product/extra.md %}#extramodifier_groups).
 
 ## `product.venue`
 {: .d-inline-block }

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -154,8 +154,12 @@ The products hero [image]({% link docs/reference/objects/image.md %}).
 {: .d-inline-block }
 boolean
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
 Returns `true` if one of the [variants]({% link docs/reference/objects/product/variant/index.md %}) in the product has an active [promotion]({% link docs/reference/objects/product/promotion.md %}).
+
+Deprecated. Not being maintained as it's no longer used in Easol themes.
 
 ## `product.highlights`
 {: .d-inline-block }

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -140,8 +140,12 @@ An array of [Image]({% link docs/reference/objects/image.md %}) objects for the 
 {: .d-inline-block }
 boolean
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
 Returns `true` if any variant on the product has infinite stock.
+
+Deprecated. Not being maintained as it's no longer used in Easol themes.
 
 ## `product.hero_image`
 {: .d-inline-block }

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -273,8 +273,12 @@ If the product is in a series this will return a [Series]({% link docs/reference
 {: .d-inline-block }
 string
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
 The path for the product's cart shop page.
+
+Deprecated, please use [shop_url]({% link docs/reference/objects/product/index.md %}#shop_url)instead.
 
 ## `product.shop_url`
 {: .d-inline-block }

--- a/docs/reference/objects/product/promotion.md
+++ b/docs/reference/objects/product/promotion.md
@@ -37,6 +37,8 @@ Returns the dates the promotion is active for as a humanized string e.g. `7 - 14
 {: .d-inline-block }
 string
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
 Returns the discount the promotion will apply, if the promotion represents a percentage discount this will be formatted as `25%` if it is a monetary discount this will be as `$25.00`.
 

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -72,6 +72,8 @@ Returns `true` if the variant has unlimited stock.
 {: .d-inline-block }
 string
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
 A humanized price e.g. `$120.00`
 


### PR DESCRIPTION
I've updated documentation on the use of modifiers, as there was some confusion around this this morning.
I've also updated all drop methods which have been commented as deprecated in easol app, other than [product.humanized_display_amount](https://github.com/easolhq/easol/blob/4a717b109ebb5faf53a79390716c7586f227b7fb/app/drops/product_drop.rb#L266) which is deprecated, but not included in the docs at all. This gets a mention in [Alchemist](https://github.com/easolhq/alchemist-theme/blob/63b87934746172b7ac796b80597de02fd594ee13/templates/product/index.text).

Should this be included in the docs? OR Is there a way for us to confirm it's not in use anywhere at all and remove from the ProductDrop entirely?