### PR TITLE
Add docs for `experience_date_search` liquid tag 

### DIFF
--- a/docs/experience_date_search/index.md
+++ b/docs/experience_date_search/index.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Experience date search
+has_children: true
+nav_order: 8
+has_toc: false
+---
+
+# Experience date search
+
+Experience date search enables you to filter a Creator's experiences with a separate result for each departure date of each experience.
+
+The experience date search is executed using the [experience_date_search tag]({% link docs/reference/tags/experience_date_search_tag/index.md %}). The tag returns an `items` array of [ExperienceDates]({% link docs/reference/objects/product/experience_date.md %}), a `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object and a `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
+
+The experience date search will only return public, published dates i.e. where the experience is published and has not been marked as private under 'Manage product availability' in the product settings.
+
+{% raw %}
+```liquid
+{% experience_date_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: 12, sort: 'departure_date_asc' %}
+  {% for item in result.items %}
+    <p>{{ item.name }}</p>
+  {% endfor %}
+  <div>
+    {{ paginate.collection_size }} Results
+    {{ paginate | default_pagination }}
+  </div>
+{% endexperience_date_search %}
+```
+{% endraw %}
+
+It's also possible to pass search parameters as query params, this is useful when building dynamic search pages.
+
+{% raw %}
+```
+http://beyondadventures.com/search?search[name]=beyond&search[departure_date][greater_than]=2021-11-22&search[sort]=departure_date_asc
+```
+{% endraw %}
+
+> Note: Parameters passed through query params will overwrite any of those specified as an attribute on the experience_date_search tag.
+
+## Pagination
+The results of the search are paginated to speed up page load, you can define the number of results displayed per page using the [page_size]({% link docs/experience_date_search/parameters.md %}#page_size) parameter.
+
+You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
+
+You can assign the value of a Liquid variable to `page_size`.
+
+## Parameters
+- [active_promotion]({% link docs/experience_date_search/parameters.md %}#active_promotion)
+- [category]({% link docs/experience_date_search/parameters.md %}#category)
+- [country]({% link docs/experience_date_search/parameters.md %}#country)
+- [departure_date]({% link docs/experience_date_search/parameters.md %}#departure_date)
+- [departure_month]({% link docs/experience_date_search/parameters.md %}#departure_month)
+- [duration]({% link docs/experience_date_search/parameters.md %}#duration)
+- [duration_unit]({% link docs/experience_date_search/parameters.md %}#duration_unit)
+- [exclude_sold_out_products]({% link docs/experience_date_search/parameters.md %}#exclude_sold_out_products)
+- [name]({% link docs/experience_date_search/parameters.md %}#name)
+- [product_id]({% link docs/experience_date_search/parameters.md %}#product_id)
+- [subcategory]({% link docs/experience_date_search/parameters.md %}#subcategory)
+- [page_size]({% link docs/experience_date_search/parameters.md %}#page_size)
+- [sort]({% link docs/experience_date_search/parameters.md %}#sort)
+
+## Accessing query params
+Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that, we can use the `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
+
+##### syntax
+{% raw %}
+```
+{{ search.departure_date }}
+```
+{% endraw %}
+
+## Sorting
+Results can be sorted ascending or descending by name, departure date or duration using the [sort]({% link docs/experience_date_search/parameters.md %}#sort) parameter.
+
+##### syntax
+{% raw %}
+```
+{% experience_date_search sort: `departure_date_asc` %}
+{% endexperience_date_search %}
+```
+{% endraw %}

--- a/docs/experience_date_search/parameters.md
+++ b/docs/experience_date_search/parameters.md
@@ -1,11 +1,8 @@
 ---
 layout: default
-title: Product search parameters
-parent: Product search
+title: Experience date search parameters
+parent: Experience date search
 ---
-
-# Product search parameters
-Product search is based on parameters that determine which products are returned and in which order.
 
 ### active_promotion
 Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
@@ -15,8 +12,8 @@ Passing `true` will only return items with a currently active [promotion]({% lin
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search active_promotion: true %}
-{% endproduct_search %}
+{% experience_date_search active_promotion: true %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -32,16 +29,17 @@ Currently, the available Easol categories are: "Festival", "Wellness", "Adventur
 
 Will accept either a single category or an array. An array must be passed explicitly (not as a Liquid variable).
 
-Will return products which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory) passed.
+Will return experience dates that belong to a product which match the [category]({% link docs/reference/objects/product/index.md %}#productcategory)
+passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search category: 'Active' %}
-{% endproduct_search %}
+{% experience_date_search category: 'Active' %}
+{% endexperience_date_search %}
 
-{% product_search subcategory: ['Active','Adventure'] %}
-{% endproduct_search %}
+{% experience_date_search subcategory: ['Active','Adventure'] %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -55,16 +53,16 @@ Accepts any of the Easol predefined [countries]({% link docs/reference/objects/p
 
 Will accept either a single country or an array. An array must be passed explicitly (not as a Liquid variable).
 
-Will return products which match the country passed.
+Will return experience dates where the product's location match the country passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search country: 'FR' %}
-{% endproduct_search %}
+{% experience_date_search country: 'FR' %}
+{% endexperience_date_search %}
 
-{% product_search country: ['FR','DE'] %}
-{% endproduct_search %}
+{% experience_date_search country: ['FR','DE'] %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -76,13 +74,13 @@ https://mysite.com/search?search[country]=DE
 ### departure_date
 Accepts an object which specifies how to handle the search through `equal_to` `greater_than` `greater_or_equal_than` or `less_than` each taking a date in SQL format `YYYY-MM-DD`. The date(s) can be passed as a Liquid variable or explicitly.
 
-Will return experiences which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#productdepart_on) range.
+Will return experience dates which depart within the [departure date]({% link docs/reference/objects/product/index.md %}#dates) range.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search departure_date: { greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
-{% endproduct_search %}
+{% experience_date_search departure_date: { greater_or_equal_than: 'now', less_than: '2023-12-28' } %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -91,8 +89,8 @@ Will return experiences which depart within the [departure date]({% link docs/re
 ```
 {% assign latest_date = opt_selected_by_user %}
 
-{% product_search departure_date: { greater_or_equal_than: 'now', less_than: latest_date } %}
-{% endproduct_search %}
+{% experience_date_search departure_date: { greater_or_equal_than: 'now', less_than: latest_date } %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -104,16 +102,16 @@ https://mysite.com/search?search[departure_date][greater_or_equal_than]=2022-11-
 ### departure_month
 Accepts a month as either a 3-letter abbreviation, or the month number i.e. `Apr` or `4`. This can be passed as a Liquid variable or explicitly.
 
-Will return experiences which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the specified month, this may be across multiple years e.g. Apr 2023 and Apr 2024.
+Will return experience dates which [depart]({% link docs/reference/objects/product/index.md %}#productdepart_on) within the specified month, this may be across multiple years e.g. Apr 2023 and Apr 2024.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search departure_month: 'Apr' %}
-{% endproduct_search %}
+{% experience_date_search departure_month: 'Apr' %}
+{% endexperience_date_search %}
 
-{% product_search departure_month: 4 %}
-{% endproduct_search %}
+{% experience_date_search departure_month: 4 %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -126,57 +124,46 @@ https://mysite.com/search?search[departure_month]=4
 ### duration
 Accepts an object which specifies how to handle the search, through `equal_to` `greater_than` or `less_than` each taking a number of days. The value(s) can be passed as a Liquid variable or explicitly.
 
-Will return experiences which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.
+Will return experience dates which have a [duration]({% link docs/reference/objects/product/index.md %}#productduration) within the defined range.
 
-Note: Experience [durations]({% link docs/reference/objects/product/index.md %}#duration) can be returned as a number of hours, 1 day or a number of nights, whereas product_search `duration` always takes the duration as a number of days or number of hours. i.e. `duration: {equal_to: 2}` will return experiences that have a duration of 2 hours or 1 night (2 days).
+Note: Experience [durations]({% link docs/reference/objects/product/index.md%}#productduration) can be returned as a number of
+hours, 1 day or a number of nights, whereas experience_date_search `duration` will by default always take the duration as a number of
+days or number of hours. i.e. `duration: {equal_to: 2}` will return experience dates that have a duration of 2 hours or 1 night (2 days).
+To specify a diferent duration, one can pass the a `duration_unit` alongside the `duration`, the accepted values as `day`, `hour` or `minute`.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search duration: {greater_than: 3, less_than: 8 } %}
-{% endproduct_search %}
+{% experience_date_search duration: {greater_than: 3, less_than: 8 }, duration_unit: "hour" %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
 ##### as a query parameter
 ```
-https://mysite.com/search?search[duration][greater_than]=3&search[duration][less_than]=8
+https://mysite.com/search?search[duration][greater_than]=3&search[duration][less_than]=8&search[duration_unit]=hour
 ```
+
+### duration_unit
+To be used in combination with [`duration`]({% link docs/experience_date_search/parameters.md %}#duration). This value can be: `day`, `hour` and `minute`.
+When no value passed it defaults to `day`.
 
 ### exclude_sold_out_products
 Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
 
-Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) products from the products returned.
+Passing `true` will exclude [sold out]({% link docs/reference/objects/product/index.md %}#productsold_out) experience dates where the product is sold out.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search exclude_sold_out_products: true %}
-{% endproduct_search %}
+{% experience_date_search exclude_sold_out_products: true %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
 ##### as a query parameter
 ```
 https://mysite.com/search?search[exclude_sold_out_products]=true
-```
-
-### include_organisation_products
-Accepts: `true` or `false`. This can be passed as a Liquid variable or explicitly.
-
-Passing `true` will include products from other companies which are linked in the same organisation.
-
-##### as a search tag attribute
-{% raw %}
-```
-{% product_search include_organisation_products: true %}
-{% endproduct_search %}
-```
-{% endraw %}
-
-##### as a query parameter
-```
-https://mysite.com/search?search[include_organisation_products]=true
 ```
 
 ### name
@@ -187,8 +174,8 @@ Will return any products whose [name]({% link docs/reference/objects/product/ind
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search name: 'my experience' %}
-{% endproduct_search %}
+{% experience_date_search name: 'my experience' %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -197,22 +184,22 @@ Will return any products whose [name]({% link docs/reference/objects/product/ind
 https://mysite.com/search?search[name]=my+experience
 ```
 
-### series_id
-Accepts a series id. This can be passed as a Liquid variable or explicitly.
+### product_id
+Accepts a product id. This can be passed as a Liquid variable or explicitly.
 
-Will return products which match the [series id]({% link docs/reference/objects/series.md %}#seriesid) passed.
+Will return dates for only the [product]({% link docs/reference/objects/product/index.md %}#productid) passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search series_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
-{% endproduct_search %}
+{% experience_date_search product_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
 ##### as a query parameter
 ```
-https://mysite.com/search?search[series_id]=abcd1234-1234-abcd-1234-abcd1234abcd
+https://mysite.com/search?search[product_id]=abcd1234-1234-abcd-1234-abcd1234abcd
 ```
 
 ### subcategory
@@ -220,16 +207,16 @@ Accepts a string and is case-sensitive. This can be passed as a Liquid variable 
 
 Will accept either a single subcategory or an array. An array must be passed explicitly (not as a Liquid variable).
 
-Will return products which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
+Will return experience dates where the  which match the [subcategory]({% link docs/reference/objects/product/index.md %}#productsubcategory) passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search subcategory: 'Wellness' %}
-{% endproduct_search %}
+{% experience_date_search subcategory: 'Wellness' %}
+{% endexperience_date_search %}
 
-{% product_search subcategory: ['4 Star','5 Star'] %}
-{% endproduct_search %}
+{% experience_date_search subcategory: ['4 Star','5 Star'] %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
@@ -248,21 +235,21 @@ Page size cannot be passed as a query parameter.
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search page_size: 8 %}
-{% endproduct_search %}
+{% experience_date_search page_size: 8 %}
+{% endexperience_date_search %}
 ```
 {% endraw %}
 
 ### sort
 Accepts `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively. This can be passed as a Liquid variable or explicitly.
 
-Will determine the order of the returned products.
+Will determine the order of the returned experience dates.
 
 ##### as a search tag attribute
 {% raw %}
 ```
-{% product_search sort: `departure_date_asc` %}
-{% endproduct_search %}
+{% experience_date_search sort: `departure_date_asc` %}
+{% endexperience_date_searchh %}
 ```
 {% endraw %}
 

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -14,11 +14,13 @@ Product search enables you to filter a Creator's experiences and accommodations,
 - Return products for a specific date range or year
 - Sort the results by departure date
 
-The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object and a `search` [Search]({% link docs/reference/objects/search_query.md %}) object. 
+The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object and a `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
 
 The product search will only return products will only return public, published products i.e. experiences and accommodations which are published and have not been marked as private under 'Manage product availability' in the product settings.
 
-> Note: Only one product_search tag should be used on a page to ensure expected results.
+> Notes:
+- Only one product_search tag should be used on a page to ensure expected results.
+- To return a separate search result for each date in an experience with multiple dates, use the [experience_date_search tag]({% link docs/reference/tags/experience_date_search_tag/index.md %})
 
 {% raw %}
 ```liquid

--- a/docs/reference/tags/experience_date_search_tag/index.md
+++ b/docs/reference/tags/experience_date_search_tag/index.md
@@ -1,0 +1,178 @@
+---
+layout: default
+title: Experience date search
+parent: Tags
+grand_parent: Reference
+---
+
+# Experience date search
+
+For additional examples see [here]({% link docs/experience_date_search/index.md %}).
+
+The experience date search tag executes a search on the company's product dates and paginates the results.
+
+##### input
+{% raw %}
+```liquid
+{% experience_date_search name: 'Beyond', duration: { greater_than: 3, less_than: 8 }, page_size: month, sort: 'departure_date_asc' %}
+    {% for item in result.items %}
+        <p>{{ item.name }}</p>
+    {% endfor %}
+    <div>
+        {{ paginate.collection_size }} Results
+        {{ paginate | default_pagination }}
+    </div>
+{% endexperience_date_search %}
+```
+{% endraw %}
+
+##### output
+{% raw %}
+```html
+<p>Beyond Sahara</p>
+<p>Beyond Archipelago</p>
+<p>Beyond Sahara Friends & Family</p>
+<p>Beyond Archipelago Friends & Family</p>
+<p>Beyond Asia</p>
+<div>
+    112 Results
+    <span class="prev">
+    <a href="http://beyondadventures.com/pagination-test?page=2">Previous</a>
+    </span>
+    <span class="page">
+    <a href="http://beyondadventures.com/pagination-test?page=1">1</a>
+    </span>
+    <span class="page">
+    <a href="http://beyondadventures.com/pagination-test?page=2">2</a>
+    </span>
+    <span class="page current">3</span>
+    <span class="page">
+    <a href="http://beyondadventures.com/pagination-test?page=4">4</a>
+    </span>
+    <span class="page">
+    <a href="http://beyondadventures.com/pagination-test?page=5">5</a>
+    </span>
+    <span class="deco">&hellip;</span>
+    <span class="page">
+    <a href="http://beyondadventures.com/pagination-test?page=9">9</a>
+    </span>
+    <span class="next">
+    <a href="http://beyondadventures.com/pagination-test?page=4">Next</a>
+    </span>
+</div>
+```
+{% endraw %}
+
+The tag returns an `items` array and a `Paginate` pagination object to the block passed in, the items array represents 1 page of the results from the search.
+
+
+## Pagination
+
+The results of this search are paginated for performance reasons.
+You can paginate results into equal page sizes, defining the number of results to display per page using the `page_size` attribute. There is a maximum page size of 100.
+Alternatively, you can paginate results by month, by setting the `page_size` to `month`.
+
+## Search Params
+
+Search params can be handled in one of two ways:
+
+### Passing explicit attributes
+
+It's possible to use any of the following attributes in the search tag itself, this is useful for building a page responsible for a specific type of product.
+
+#### active_promotion
+Passing `true` to this will mean all items returned will have a currently active promotion.
+
+#### category
+Will search for experience dates which match the category passed, this must use one of Easol's predefined categories and will accept either a single Category or an array.
+
+#### country
+This attribute accepts either Country Codes or Country Names and can be passed as a single attribute or as an array, e.g. `country: ['FR', 'DE']`
+
+#### departure_date
+This attribute takes an object which specifies how to handle the search, through `equal_to` `greater_than` `greater_or_equal_than` or `less_than`
+each taking a date in SQL format `YYYY-MM-DD` e.g. `departure_date: {greater_than: 'now', less_than: '2019-12-28' }`
+
+#### departure_month
+This allows you to specify which month the trips should depart in, e.g. passing `departure_date: 'Apr'` would return any
+trips departing in April 2020, April 2021 ..., You can also pass the number of the month i.e. `departure_month: 4` would return the same results.
+
+#### duration
+This attribute takes an object which specifies how to handle the search,
+through `equal_to` `greater_than` or `less_than` each taking a number of days
+e.g. `duration: {greater_than: 3, less_than: 8 }`.
+The value passed defaults to a `duration_unit` of `day`. There are three possible values, `day`, `hour` and `minute`.
+To define a `duration_unit` just add it to the search params e.g. `duration: {greater_than: 3, less_than: 8 }, duration_unit: 'hour'`.
+
+#### duration_unit
+To be used in combination with [`duration`]({% link docs/reference/tags/experience_date_search_tag/index.md %}#duration). This value can be: `day`, `hour` and `minute`.
+When no value passed it defaults to `day`.
+
+#### name
+This executes a partial search on the string passed in and will return any dates where the products whose name matches the argument.
+
+#### product_id
+ The `id` of the product to filter by.
+
+#### subcategory
+Will search for experience dates which match the subcategory passed, this must use one of Easol's predefined subcategories and will accept either a single Subcategory or an array.
+
+#### page_size
+Will determine how many results are shown per page. If this is not included it will default to 12 results per page. e.g. `page_size: 12`.
+There is a maximum page size of 100. If a larger number is provided results will be capped at 100 per page.
+You can set this to `month` to return all results in a month per page (to display in a calendar view).
+`week`???
+
+#### sort
+The sorting order of results. The available options are: `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` and `departure_date_desc`, where the `_asc` and `_desc` parts represent ascending and descending orders respectively.
+### As query params
+
+It's also possible to pass search params as query params, this is useful when building dynamic search pages.
+
+Any of the above attributes can be used as a query param and should all be namespaced to search
+
+e.g.
+`http://beyondadventures.com/search?search[name]=beyond&search[departure_date][greater_than]=2021-11-22`
+
+Params passed through a query param will overwrite any of those specified as an attribute
+
+## Sorting
+
+It's possible to also sort the results by name, departure date and duration. This can be done either through an attribute on the tag or through the search query param.
+
+These should be passed as a string describing the dimension to sort on and the direction either ascending or descending. i.e. one of
+
+`name_asc` `name_desc` `duration_asc` `duration_desc` `departure_date_asc` `departure_date_desc`
+
+{% raw %}
+```liquid
+{% product_search name: 'Beyond', sort: 'name_asc' %}
+    {% for item in result.items %}
+        <p>{{ item.name }}</p>
+    {% endfor %}
+    <div>
+        {{ paginate.collection_size }} Results
+        {{ paginate | default_pagination }}
+    </div>
+{% endproduct_search %}
+```
+{% endraw %}
+
+or
+
+`http://beyondadventures.com/search?search[name]=beyond&search[sort]=name_asc`
+
+## Accessing the query params
+
+Once the search has been executed, it can be helpful to get a reference to the params and values in the search.
+For that, we can use the `Search` object, which exposes all of the params listed above in the "Passing explicit attributes" section.
+
+{% raw %}
+```liquid
+{{ search.departure_date }}
+
+or
+
+{{ search["departure_date"] }}
+```
+{% endraw %}


### PR DESCRIPTION
Docs for the newly introduced `experience_date_search` tag.

Tag PR [here](https://github.com/easolhq/easol/pull/9096).
Search done under the hood work [here](https://github.com/easolhq/easol/pull/9064).