### PR TITLE
Experience date drop only 2

### DIFF
--- a/docs/reference/objects/product/experience_date.md
+++ b/docs/reference/objects/product/experience_date.md
@@ -24,7 +24,7 @@ This can then be used in conjunction with Liquid's [built-in filters](https://sh
 array of [Extra]({% link docs/reference/objects/product/extra.md %})s
 {: .label .fs-1 }
 
-An array of the date's [extras]({% link docs/reference/objects/product/extra.md %})
+An array of the date's [extras]({% link docs/reference/objects/product/extra.md %}).
 
 ## `experience_date.featured_variant`
 {: .d-inline-block }

--- a/docs/reference/objects/product/experience_date.md
+++ b/docs/reference/objects/product/experience_date.md
@@ -42,6 +42,12 @@ The dates of the experience date as a formatted string.
 e.g. `15 November 2024` for an experience with a duration of less than or equal to one day.
 e.g. `15 - 20 November 2024` for an experience with a duration of more than one day.
 
+## `experience_date.id`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The experience date id.
 ## `experience_date.product`
 {: .d-inline-block }
 [Product]({% link docs/reference/objects/product/index.md %})

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -83,13 +83,6 @@ string
 
 The duration of the product including duration unit e.g. `5 nights`.
 
-## `product.experience_dates`
-{: .d-inline-block }
-[ExperienceDate]({% link docs/reference/objects/product/experience_date.md %})
-{: .label .fs-1 }
-
-An array of the product's [experience dates]({% link docs/reference/objects/product/experience_date.md %})
-
 ## `product.enquire_only`
 {: .d-inline-block }
 boolean


### PR DESCRIPTION
Follow up to [PR#124](https://github.com/easolhq/easolhq.github.io/pull/124).

~~In testing behaviour of accommodations, I've noticed we haven't implemented an `experience_dates` method on the product drop just yet. I'm suggesting it should return all upcoming and ongoing, therefore none if they're all past? Added ticket to our backlog here https://trello.com/c/LTPg7VXi/251-productdrop-responds-to-experiencedates~~ we want results to always be paginated. Removing docs to `product.experience_dates` in this PR.