### PR TITLE
fix: ensuring correct formatting is maintained

### DIFF
--- a/docs/reference/objects/cart/cart_item.md
+++ b/docs/reference/objects/cart/cart_item.md
@@ -70,7 +70,6 @@ The start date of the product associated with the cart item.
 ## `item.sub_items`
 {: .d-inline-block }
 array of [Cart item]({% link docs/reference/objects/cart/cart_item.md %})s
-
 {: .label .fs-1 }
 
 The related sub-items for a [Cart item]({% link docs/reference/objects/cart/cart_item.md %}). Currently these are available for cart items that are for a custom-priced package, and the sub-items are all other line items that are part of its package booking.


### PR DESCRIPTION
Additional empty line introduced in https://github.com/easolhq/easolhq.github.io/commit/85458a6dda6933f0f034a26680203142ea1e6b30 was causing the elements to be formatted incorrectly.

Before:
![Screenshot 2023-06-19 at 15 51 31](https://github.com/easolhq/easolhq.github.io/assets/12126304/ec21b44d-d9de-45fb-8bba-ba461c1bb9ad)

After:
![Screenshot 2023-06-19 at 15 51 25](https://github.com/easolhq/easolhq.github.io/assets/12126304/afadd5e0-c26f-4ee4-865b-93b09c50ea8f)
