### PR TITLE
fix: resolving typo in package step drop

### DIFF
--- a/docs/reference/objects/package/step.md
+++ b/docs/reference/objects/package/step.md
@@ -73,7 +73,7 @@ Date
 
 Creators may specify that customers must book accommodation dates which include a specific date range. This will return the end date of that range.
 
-## `package_step.next_step_path`
+## `package_step.next_page_path`
 {: .d-inline-block }
 URL
 {: .label .fs-1 }


### PR DESCRIPTION
Currently the docs list `next_step_path`, however `next_page_path` is actually what's exposed.

Personally I feel that `next_step_path` makes more sense based on the context, so ideally we'd changed what's exposed. But aware that's going to have bigger implications, as we'll need to go through and update it in the templates for any site running the existing code. Keen to hear your thoughts on if you think the value in changing that outweigh the work involved, or whether we just roll with this change to ensure the docs are correct.