### PR TITLE
Global vs date specific modifier behaviour

### DIFF
--- a/docs/reference/objects/product/modifier.md
+++ b/docs/reference/objects/product/modifier.md
@@ -10,6 +10,14 @@ grand_parent: Objects
 object
 {: .label .fs-1 }
 
+
+The modifier object will behave slightly differently depending on how it is accessed.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), some methods will return a result that is specific to that given date.
+- When accessed independently or through a product, those methods will take into account all upcoming dates on the product.
+
+Please check the method descriptions for more details.
+
+
 #### Attributes
 
 ## `modifier.id`
@@ -127,6 +135,8 @@ boolean
 {: .label .fs-1 }
 
 Returns `true` if the modifier has unlimited stock.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), it will return `true` if the modifier has unlimited stock on the given date.
+- When accessed independently or through a product, it will return `true` if the modifier has unlimited stock on at least one of the upcoming dates.
 
 ## `modifier.image`
 {: .d-inline-block }
@@ -141,6 +151,8 @@ number
 {: .label .fs-1 }
 
 The initial stock for the modifier. If the modifier has unlimited inventory this will return `nil`.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), it will return the initial stock for the modifier on the given date.
+- When accessed independently or through a product, it will return the sum of the initial stock for the modifier across all upcoming dates.
 
 ## `modifier.label_attributes`
 {: .d-inline-block }
@@ -169,6 +181,8 @@ number
 
 The price of the modifier as a fractional in the sub-unit of the current customer's currency.
 e.g. considering the amount $19.50, it will return 1950.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), it will return the price for the modifier on the given date.
+- When accessed independently or through a product, it will return the default price for the modifier, managed in **Experience > Modifiers**.
 
 ## `modifier.remaining_stock`
 {: .d-inline-block }
@@ -176,6 +190,8 @@ number
 {: .label .fs-1 }
 
 The remaining stock for the modifier. If the modifier has unlimited inventory this will return `nil`.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), it will return the remaining stock for the modifier on the given date.
+- When accessed independently or through a product, it will return the sum total of remaining stock for the modifier across all upcoming dates.
 
 ## `modifier.selected`
 {: .d-inline-block }
@@ -190,6 +206,8 @@ boolean
 {: .label .fs-1 }
 
 Returns `true` if the modifier is sold out.
+- When accessed through an [experience date]({% link docs/reference/objects/product/experience_date.md %}), it will return `true` if the modifier is sold out on the given date.
+- When accessed independently or through a product, it will return `true` if the modifier is sold out across all upcoming dates.
 
 ## `modifier.start_at`
 {: .d-inline-block }


### PR DESCRIPTION
This PR follows on from [this PR](https://github.com/easolhq/easolhq.github.io/pull/139).  
We did not initially intend to have modifiers available on a per-date basis... we are now!
So updating the modifier docs to reflect this.
