### PR TITLE
experience_slot_search parameter product_id accepts an array

### DIFF
--- a/docs/experience_slot_search/parameters.md
+++ b/docs/experience_slot_search/parameters.md
@@ -166,14 +166,21 @@ https://mysite.com/search?search[name]=my+experience
 ```
 
 ### product_id
-Accepts a product id. This can be passed as a Liquid variable or explicitly.
+Will accept either a single product id or an array. This can be passed as a Liquid variable or explicitly.
 
-Will return slots for only the [product]({% link docs/reference/objects/product/index.md %}#productid) passed.
+Will return slots for only the [product ids]({% link docs/reference/objects/product/index.md %}#productid) passed.
 
 ##### as a search tag attribute
 {% raw %}
 ```
 {% experience_slot_search product_id: 'abcd1234-1234-abcd-1234-abcd1234abcd' %}
+{% endexperience_slot_search %}
+
+{% experience_slot_search product_id: ['abcd1234-1234-abcd-1234-abcd1234abcd', 'wxyz9876-9876-wxyz-9876-wxyz9876wxyz'] %}
+{% endexperience_slot_search %}
+
+{% assign product_ids = products | map: "id" %}
+{% experience_slot_search product_id: product_ids %}
 {% endexperience_slot_search %}
 ```
 {% endraw %}

--- a/docs/reference/tags/experience_slot_search_tag/index.md
+++ b/docs/reference/tags/experience_slot_search_tag/index.md
@@ -157,7 +157,7 @@ When no value passed it defaults to `day`.
 This executes a partial search on the string passed in and will return any dates where the products whose name matches the argument.
 
 #### product_id
- The `id` of the product to filter by.
+ The `id` of the product to filter by. It will accept either a single id or an array.
 
 #### subcategory
 Will search for experience dates which match the subcategory passed, this must use one of Easol's predefined subcategories and will accept either a single Subcategory or an array.


### PR DESCRIPTION
Following on from PR [Experience slot search accepts array of product ids #11340](https://github.com/easolhq/easol/pull/11340), you can pass an array to this parameter. Updating the docs to reflect this.

<img width="1276" alt="Screenshot 2023-10-17 at 11 52 16" src="https://github.com/easolhq/easolhq.github.io/assets/78875971/214525aa-40fe-489d-988f-0a79c22d1cbb">
<img width="715" alt="Screenshot 2023-10-17 at 11 53 15" src="https://github.com/easolhq/easolhq.github.io/assets/78875971/08ff2c6f-bdd9-41fb-afd5-c90aa7b6a5c0">
