### PR TITLE
Document `experience_slot.deposit`

### DIFF
--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -89,3 +89,12 @@ array of [variant]({% link docs/reference/objects/product/variant/index.md %})s
 {: .label .fs-1 }
 
 An array of the slot's [variants]({% link docs/reference/objects/product/variant/index.md %}).
+
+## `experience_slot.deposit`
+{: .d-inline-block }
+[Deposit]({% link docs/reference/objects/product/deposit.md %})
+{: .label .fs-1 }
+
+The [deposit]({% link docs/reference/objects/product/deposit.md %}) for this
+slot's experience. The returned deposit will consider this slot's `start_on`
+when determining if the deposit is enabled for use.


### PR DESCRIPTION
We've added this to reflect the deposit for an experience on a specific slot date.

![Screenshot 2023-10-24 at 14 42 55](https://github.com/easolhq/easolhq.github.io/assets/5904028/17d7f17e-a2c4-4f0a-a054-d584d9fb7efc)

[The relevant platform-side PR for this change is here](https://github.com/easolhq/easol/pull/11434).