### PR TITLE
Document experience_variant `payment_plan` method

### DIFF
--- a/docs/reference/objects/product/variant/experience_variant/index.md
+++ b/docs/reference/objects/product/variant/experience_variant/index.md
@@ -18,9 +18,23 @@ it has access to the following attributes.
 
 #### Attributes
 
+## `experience_variant.payment_plan`
+{: .d-inline-block }
+[Payment Plan]({% link docs/reference/objects/product/variant/payment_plan.md %})
+{: .label .fs-1 }
+
+The same as [variant]({% link
+docs/reference/objects/product/variant/index.md %}) `deposit` method
+with the caveat that if the experience variant is accessed through an
+[experience slot]({% link docs/reference/objects/product/experience_slot.md
+%}), a [payment plan]({% link
+docs/reference/objects/product/variant/payment_plan.md %}) will only be
+returned if the last payment date is before the slot's `start_on`.
+
 ## `experience_variant.type`
 {: .d-inline-block }
 string
 {: .label .fs-1 }
 
 Will return `experience_variant`.
+

--- a/docs/reference/objects/product/variant/experience_variant/index.md
+++ b/docs/reference/objects/product/variant/experience_variant/index.md
@@ -18,6 +18,18 @@ it has access to the following attributes.
 
 #### Attributes
 
+## `experience_variant.deposit`
+{: .d-inline-block }
+[Deposit]({% link docs/reference/objects/product/deposit.md %})
+{: .label .fs-1 }
+
+The [deposit]({% link docs/reference/objects/product/deposit.md %}) of this
+experience variant if there's a deposit present on the product. If the
+experience variant is accessed through an [experience slot]({% link
+docs/reference/objects/product/experience_slot.md %}), the deposit will consider
+its availability on that specific slot, otherwise it will consider the last
+available slot's `start_on`.
+
 ## `experience_variant.payment_plan`
 {: .d-inline-block }
 [Payment Plan]({% link docs/reference/objects/product/variant/payment_plan.md %})


### PR DESCRIPTION
The logic for `payment_plan` changes slightly specific for experience variants when accessed through a slot, which we document here.

[The relevant platform PR for this change is here](https://github.com/easolhq/easol/pull/11449).