### PR TITLE
Slug 345 add experience slots calendar liquid tag

### DIFF
--- a/docs/experience_slot_calendar/index.md
+++ b/docs/experience_slot_calendar/index.md
@@ -1,0 +1,165 @@
+---
+layout: default
+title: Experience slot calendar
+has_children: true
+nav_order: 8
+has_toc: false
+---
+
+# Experience slot calendar
+
+The `experience_slot_calendar` provides a way to render a calendar month with information about what experience slots are available on each date. The tag is scoped to one or more experiences.
+
+The tag makes a [calendar]({% link docs/reference/objects/experience_slot_calendar/calendar.md %}) object available, which contains an array of [dates]({% link docs/reference/objects/experience_slot_calendar/date.md %}). Each `date` has information about the experience slots that are available on the date, such as `date.slot_count`, `date.sold_out`, `date.display_price` and `date.slots_by_variant`.
+
+The [calendar]({% link docs/reference/objects/experience_slot_calendar/calendar.md %}) object also includes information about the current, next and previous months. Combining this with the use of the [search]({% link docs/reference/objects/search_query.md %}) object, it is possible to build a calendar UI that allows a user to navigate between months. See the example in [Navigatable calendar UI]({% link docs/experience_slot_calendar/index.md %}#navigatable-calendar-ui) for how this is possible.
+
+The [date]({% link docs/reference/objects/experience_slot_calendar/date.md %}) object will ignore variants that have been hidden on specific experience slots.
+
+> Note: Unlike the [product_search]({% link docs/product_search/index.md %}) and [experience_slot_search]({% link docs/experience_slot_search/index.md %}), parameters passed through query params will not be used automatically by the `experience_slot_calendar` calendar. Any parameters need to be explicitly passed into the tag as arguments.
+
+##### input
+{% raw %}
+```liquid
+{% experience_slot_calendar experience: product, month: 2, year: 2024 %}
+  <ul>
+    {% for date in calendar.dates %}
+      <li>
+        {{ date.date | date: "%Y-%m-%d" }}
+        {% if date.slot_count == 0 %}
+          (no availability)
+        {% elsif date.sold_out %}
+          (sold out)
+        {% else %}
+           (from {{ date.display_price.fractional | money }})
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endexperience_slot_calendar %}
+```
+{% endraw %}
+
+##### output
+{% raw %}
+```html
+  <ul>
+    <li>2024-02-01 (from £18.00)</li>
+    <li>2024-02-02 (from £18.00)</li>
+    <li>2024-02-03 (from £18.00)</li>
+    <li>2024-02-04 (sold out)</li>
+    <li>2024-02-05 (sold out)</li>
+    <li>2024-02-06 (sold out)</li>
+    <li>2024-02-07 (sold out)</li>
+    <li>2024-02-08 (sold out)</li>
+    <li>2024-02-09 (sold out)</li>
+    <li>2024-02-10 (from £5.00)</li>
+    <li>2024-02-11 (from £5.00)</li>
+    <li>2024-02-12 (from £5.00)</li>
+    <li>2024-02-13 (from £5.00)</li>
+    <li>2024-02-14 (no availability)</li>
+    <li>2024-02-15 (no availability)</li>
+    <li>2024-02-16 (no availability)</li>
+    <li>2024-02-17 (no availability)</li>
+    <li>2024-02-18 (no availability)</li>
+    <li>2024-02-19 (from £18.00)</li>
+    <li>2024-02-20 (from £18.00)</li>
+    <li>2024-02-21 (from £18.00)</li>
+    <li>2024-02-22 (from £18.00)</li>
+    <li>2024-02-23 (from £18.00)</li>
+    <li>2024-02-24 (from £18.00)</li>
+    <li>2024-02-25 (from £18.00)</li>
+    <li>2024-02-26 (from £18.00)</li>
+    <li>2024-02-27 (from £18.00)</li>
+    <li>2024-02-28 (from £18.00)</li>
+    <li>2024-02-29 (from £18.00)</li>
+  </ul>
+```
+{% endraw %}
+
+## Parameters
+- `experience` [required]
+  - This can be a `ProductDrop`, a string of the product ID or an array containing a combination of either.
+- `month`
+  - The month as a number, e.g. `2` would represent February.
+  - This argument is ignored if `year` is blank.
+  - If this is blank, it will default the next month that contains available slots.
+- `year`
+  - The year as a number, e.g. `2023`.
+  - This argument is ignored if `month` is blank.
+  - If this is blank, it will default the year of the next month that contains available slots.
+
+## Navigatable calendar UI
+
+It is possible to send the `month` and `year` parameters in the URL via the `?search` query param and for these properties to be available via the `search` drop, e.g. `search.month` and `search.year`. For example, a URL might look like the following:
+
+`https://my-easol-site.com/my-calendar-page?search[month]=2&search[year]=2023`
+
+We can pass these properties directly into the tag as arguments. If the `month` or `year` arguments are blank, it will default to using the next month that contains available experience slots.
+
+The [calendar]({% link docs/reference/objects/experience_slot_calendar/calendar.md %}) object also exposes the current, next and previous months, which allows building a navigatable calendar UI.
+
+The `calendar.first_day` method returns the first day in the month as a date, which can be used to render the name of the month. The same can be done with the next and previous months, e.g. `{% raw %}{{ calendar.next.first_day | date: "%B %Y" }}{% endraw %}`.
+
+##### syntax
+{% raw %}
+```
+{% experience_slot_calendar experience: product, month: search.month, year: search.year %}
+  <h5>{{ calendar.first_day | date: "%B %Y" }}</h5>
+
+  <ul>
+    {% for date in calendar.dates %}
+      <li>
+        {{ date.date | date: "%Y-%m-%d" }}
+      </li>
+    {% endfor %}
+  </ul>
+
+  <div>
+    <a href="?search[month]={{calendar.prev.month}}&search[year]={{calendar.prev.year}}">
+      {{ calendar.prev.first_day | date: "%B %Y" }}
+    </a>
+    <a href="?search[month]={{calendar.next.month}}&search[year]={{calendar.next.year}}">
+      {{ calendar.next.first_day | date: "%B %Y" }}
+    </a>
+  </div>
+{% endexperience_slot_calendar %}
+```
+{% endraw %}
+
+## Experiences with multiple time slots per day
+
+It is possible for experiences to have multiple time slots on the same day. The `date.slots_by_variant` method can be used to display price and stock information for variants on each specific time slot.
+
+##### syntax
+{% raw %}
+```
+{% experience_slot_calendar experience: product %}
+  <ul>
+    {% for date in calendar.dates %}
+      <li>
+        {{ date.date | date: "%Y-%m-%d" }}
+
+        {% for slot_variant in date.slots_by_variant %}
+          <details>
+            <summary>{{ slot_variant.variant.name }}</summary>
+            <ul>
+              {% for slot in slot_variant.slots %}
+              <li>
+                {{ slot.start_time }} ({{ slot.price.fractional | money }})
+                {% if slot.sold_out %}
+                  sold out
+                {% elsif slot.remaining_stock < 5 %}
+                  only {{ slot.remaining_stock }} stock left
+                {% endif %}
+              </li>
+              {% endfor %}
+            </ul>
+          </details>
+        {% endfor %}
+      </li>
+    {% endfor %}
+  </ul>
+{% endexperience_slot_calendar %}
+```
+{% endraw %}

--- a/docs/reference/objects/experience_slot_calendar/calendar.md
+++ b/docs/reference/objects/experience_slot_calendar/calendar.md
@@ -1,0 +1,61 @@
+---
+layout: default
+title: Calendar
+parent: Experience Slot Calendar
+grand_parent: Objects
+---
+
+# Calendar
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+#### Attributes
+
+## `calendar.dates`
+{: .d-inline-block }
+array of [dates]({% link docs/reference/objects/experience_slot_calendar/date.md %})
+{: .label .fs-1 }
+
+The dates within this calendar month.
+
+## `calendar.first_day`
+{: .d-inline-block }
+date
+{: .label .fs-1 }
+
+The first day in this calendar month. This can be used along with the Liquid's [date filter](https://shopify.github.io/liquid/filters/date/) filter to display the name of the month, e.g. `{% raw %}{{ calendar.next.first_day | date: "%B %Y" }}{% endraw %}`.
+
+## `calendar.month`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The number of the calendar month.
+
+## `calendar.next`
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+An object representing the next calendar month, which includes the following methods:
+- `first_day`
+- `month`
+- `year`
+
+## `calendar.prev`
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+An object representing the previous calendar month, which includes the following methods:
+- `first_day`
+- `month`
+- `year`
+
+## `calendar.year`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The number of the calendar year.

--- a/docs/reference/objects/experience_slot_calendar/date.md
+++ b/docs/reference/objects/experience_slot_calendar/date.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Date
+parent: Experience Slot Calendar
+grand_parent: Objects
+---
+
+# Date
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+#### Attributes
+
+## `date.date`
+{: .d-inline-block }
+timestamp
+{: .label .fs-1 }
+
+The date.
+
+## `date.display_price`
+{: .d-inline-block }
+[price]({% link docs/reference/objects/product/price.md %})
+{: .label .fs-1 }
+
+The display price for this date in the current user's currency.
+
+This is determined by finding the cheapest variant that is available across the slots for this date. If an experience has defined a "display" variant, it will use the price of that variant and ignore prices of other variant from that experience.
+
+The price used is the total price of the variant at its maximum occupancy, not the per person price, and promotions are not taken into consideration.
+
+## `date.slot_count`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The number of slots available on this date.
+
+## `date.slots_by_variant`
+{: .d-inline-block }
+array of objects
+{: .label .fs-1 }
+
+This returns slot information grouped by variant. It will return an array of objects, each containing the following methods:
+
+- `variant`{: .d-inline-block }
+  [variant]({% link docs/reference/objects/product/variant/index.md %}){: .label .fs-1 }
+
+- `slots`{: .d-inline-block }
+  [array of slots]({% link docs/reference/objects/experience_slot_calendar/slot.md %}){: .label .fs-1 }
+
+
+## `date.sold_out`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+This returns true if all variants are sold out across all slots on this date.

--- a/docs/reference/objects/experience_slot_calendar/index.md
+++ b/docs/reference/objects/experience_slot_calendar/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Experience Slot Calendar
+parent: Objects
+has_children: true
+---
+
+# Experience Slot Calendar
+
+These objects are used within the [experience_slot_calendar]({% link docs/experience_slot_calendar/index.md %}) tag.

--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -1,0 +1,71 @@
+---
+layout: default
+title: Slot
+parent: Experience Slot Calendar
+grand_parent: Objects
+---
+
+# Slot
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+#### Attributes
+
+## `slot.end_on`
+{: .d-inline-block }
+timestamp
+{: .label .fs-1 }
+
+The date the slot ends on. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
+
+## `slot.id`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The ID of the experience slot.
+
+## `slot.price`
+{: .d-inline-block }
+[price]({% link docs/reference/objects/product/price.md %})
+{: .label .fs-1 }
+
+The price of this variant on this slot in the current user's currency.
+
+## `slot.remaining_stock`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The remaining stock for this variant on this slot. It will return nil if there is infinite stock.
+
+## `slot.shop_url`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The url for the cart shop page with this slot preselected.
+
+## `slot.sold_out`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+This returns true if the variant is sold out on this slot.
+
+## `slot.start_on`
+{: .d-inline-block }
+timestamp
+{: .label .fs-1 }
+
+The date the slot starts on. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
+
+## `slot.start_time`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The start time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
+
+This will return nil if the experience does not have a start time.

--- a/docs/reference/objects/search_query.md
+++ b/docs/reference/objects/search_query.md
@@ -52,7 +52,7 @@ Returns the departure_month as a string in the form it was passed in i.e. `Jan` 
 object
 {: .label .fs-1 }
 
-Returns the duration as an object i.e. `{"greater_than"=>"3", "less_than"=>"8"}`. 
+Returns the duration as an object i.e. `{"greater_than"=>"3", "less_than"=>"8"}`.
 Specific values can be accessed via: `search.duration.equal_to`, `search.duration.greater_than` and `search.duration.less_than` as relevant.
 
 ## `search.exclude_sold_out_products`
@@ -68,6 +68,13 @@ boolean
 {: .label .fs-1 }
 
 Returns `true` or `false`.
+
+## `search.month`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+Returns the month as a number, e.g. `2` would represent February.
 
 ## `search.series_id`
 {: .d-inline-block }
@@ -89,3 +96,10 @@ string
 {: .label .fs-1 }
 
 Returns `name_asc`, `name_desc`, `duration_asc`, `duration_desc`, `departure_date_asc` or `departure_date_desc`.
+
+## `search.year`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+Returns the year as a number, e.g. `2023`.

--- a/docs/reference/tags/experience_slot_calendar_tag/index.md
+++ b/docs/reference/tags/experience_slot_calendar_tag/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Experience slot calendar
+parent: Tags
+grand_parent: Reference
+---
+
+# Experience slot calendar
+
+Information about this tag can be seen [here]({% link docs/experience_slot_calendar/index.md %}).


### PR DESCRIPTION
This PR adds documentation for the new `experience_slot_calendar` tag.