### PR TITLE
Document payment_plan on ExperienceSlot

### DIFF
--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -66,6 +66,17 @@ string
 {: .label .fs-1 }
 
 The experience slot id.
+
+## `experience_slot.payment_plan`
+{: .d-inline-block }
+[Payment Plan]({% link docs/reference/objects/product/variant/payment_plan.md %})
+{: .label .fs-1 }
+
+Returns a [payment plan]({% link
+docs/reference/objects/product/variant/payment_plan.md %}) if one is available
+on this slot's experience and the last payment date is before the slot's
+`start_on`.
+
 ## `experience_slot.product`
 {: .d-inline-block }
 [Product]({% link docs/reference/objects/product/index.md %})


### PR DESCRIPTION
We've just added the ability to fetch the payment plan, if one is available, through the ExperienceSlotDrop.

To be merged after https://github.com/easolhq/easol/pull/11982.