### PR TITLE
feat: add missing included items drops

### DIFF
--- a/docs/reference/objects/package/item.md
+++ b/docs/reference/objects/package/item.md
@@ -27,3 +27,17 @@ The unique id of the item.
 {: .label .fs-1 }
 
 The variant of the item.
+
+## `item.adult_count`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The number of guests for the item.
+
+## `item.quantity`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The quantity of the item.

--- a/docs/reference/objects/package/item.md
+++ b/docs/reference/objects/package/item.md
@@ -19,6 +19,7 @@ Represents an included item in a [package]({% link docs/reference/objects/packag
 {: .d-inline-block }
 string
 {: .label .fs-1 }
+
 The unique id of the item.
 
 ## `item.variant`


### PR DESCRIPTION
Adding details on how to access the adult count and the quantity on a package item.

Can be previewed [here](http://localhost:4000/docs/reference/objects/package/item.html) when run locally.

![CleanShot 2023-12-26 at 12 14 59](https://github.com/easolhq/easolhq.github.io/assets/48216064/cf44e1d3-006a-4939-9761-09d261a63e09)
