### PR TITLE
Sun 34 Document experience_slot block variable

### DIFF
--- a/docs/theme_architecture/blocks/schema/variables/variable_types/experience_date.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/experience_date.md
@@ -13,6 +13,8 @@ Returns an [Experience Slot Calendar Date]({% link docs/reference/objects/experi
 
 Accepts a `default` of `next_upcoming` which will select the next available date from the Creator's published experiences.
 
+> Note: For performance reasons, the variants available via experience_date will be the 'blueprint' variant, i.e. it will have default pricing and stock levels. This does not match the specific pricing and stock for the variant on the chosen date if overrides have been applied.
+
 ##### syntax
 {% raw %}
 ```

--- a/docs/theme_architecture/blocks/schema/variables/variable_types/experience_slot.md
+++ b/docs/theme_architecture/blocks/schema/variables/variable_types/experience_slot.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Experience Slot
+parent: Variable types
+has_children: false
+---
+
+# Experience Slot
+
+Renders two or three inputs. Firstly, the Creator selects an experience as well as a date from available dates for the chosen experience. If the experience has start times, they can then choose a time for the selected date.
+
+Returns an [Experience Slot]({% link docs/reference/objects/product/experience_slot.md %}) object.
+
+##### syntax
+{% raw %}
+```
+---
+attributes:
+  my_variable:
+    type: experience_slot
+---
+
+{% if my_variable %}
+  {{ my_variable.start_on | date: "%-d %B %Y" }}{{ my_variable.start_time | date: " · %H:%M" }}
+{% endif %}
+```
+{% endraw %}


### PR DESCRIPTION
As it says on the tin! Does the 'note' make sense? All suggested changes very welcome 🙏 

<img width="1244" alt="Screenshot 2024-01-09 at 17 29 05" src="https://github.com/easolhq/easolhq.github.io/assets/78875971/ad216ab5-980c-4892-88c3-0038ecfc2500">
