### PR TITLE
Document CartItem#experience_slot

### DIFF
--- a/docs/reference/objects/cart/cart_item.md
+++ b/docs/reference/objects/cart/cart_item.md
@@ -25,6 +25,14 @@ timestamp
 
 The end date of the product associated with the cart item.
 
+## `item.experience_slot`
+{: .d-inline-block }
+[Experience Slot]({% link docs/reference/objects/product/experience_slot.md %})
+{: .label .fs-1 }
+
+The [Experience Slot]({% link docs/reference/objects/product/experience_slot.md
+%}) for the cart item, if the cart item product is an Experience-type.
+
 ## `item.id`
 {: .d-inline-block }
 string


### PR DESCRIPTION
If the cart item is for an experience, this method will return it's ExperienceSlotDrop.

[Platform-side change here](https://github.com/easolhq/easol/pull/12150).