### PR TITLE
Update slot docs

### DIFF
--- a/docs/reference/objects/experience_slot_calendar/date.md
+++ b/docs/reference/objects/experience_slot_calendar/date.md
@@ -26,9 +26,12 @@ The date.
 
 The display price for this date in the current user's currency.
 
-This is determined by finding the cheapest variant that is available across the slots for this date. If an experience has defined a "display" variant, it will use the price of that variant and ignore prices of other variant from that experience.
+This is determined by finding the cheapest variant that is available across the slots for this date, accounting for promotions.
 
-The price used is the total price of the variant at its maximum occupancy, not the per person price, and promotions are not taken into consideration.
+The price used is the price of the variant at its maximum occupancy, not the per person price.
+
+If an experience has a "display" variant defined, it will use the price of that variant and ignore prices of other variant from that experience.
+
 
 ## `date.experience`
 {: .d-inline-block }

--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -10,6 +10,11 @@ grand_parent: Objects
 object
 {: .label .fs-1 }
 
+
+*Note:* This is a slot accessed via [calendar `dates`]({% link docs/reference/objects/experience_slot_calendar/date.md %}). Not to be mistaken for an [`experience_slot`]({% link docs/reference/objects/product/experience_slot.md %}).
+
+<br>
+
 #### Attributes
 
 ## `slot.end_on`

--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -19,7 +19,7 @@ timestamp
 
 The date the slot ends on. This can then be used in conjunction with Liquid's [built-in filters](https://shopify.github.io/liquid/filters/date/).
 
-## `experience_slot.end_time`
+## `slot.end_time`
 {: .d-inline-block }
 string
 {: .label .fs-1 }

--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -10,6 +10,10 @@ has_children: false
 object
 {: .label .fs-1 }
 
+*Note:* Experience slots are returned as part of an [`experience_slot_search`]({% link docs/experience_slot_search/index.md %}) or when using the [`experience_slot` variable type]({% link docs/theme_architecture/blocks/schema/variables/variable_types/experience_slot.md %}). Not to be mistaken for a [calendar `slot`]({% link docs/reference/objects/experience_slot_calendar/slot.md %}).
+
+<br>
+
 #### Attributes
 
 ## `experience_slot.deposit`


### PR DESCRIPTION
As discussed in Slack - I am updating docs to reflect changes made in Nov to date.display_price. Apologies for missing this in Nov, not an excuse but seems to have been lost during the period of team changes.

I've also added some clarifying info because I am regularly confused between slot and experience_slot