### PR TITLE
Sun 172 expose deposit due date information to frontend

### DIFF
--- a/docs/pricing_and_payments/deposits.md
+++ b/docs/pricing_and_payments/deposits.md
@@ -8,7 +8,7 @@ parent: Pricing & payments
 
 For quick reference please see [Deposit]({% link docs/reference/objects/product/deposit.md %}).
 
-Setting a deposit on a product allows customers to choose to pay a percentage of the total product price at the time of booking, and the remaining balance any time before the due date. 
+Setting a deposit on a product allows customers to choose to pay a percentage or fixed amount of the total product price at the time of booking, and the remaining balance any time before the due date.
 
 A deposit is set at a product level and applies to all [variants]({% link docs/reference/objects/product/variant/index.md %}) and [extras]({% link docs/reference/objects/product/extra.md %}) of that product. It does not apply to [modifiers]({% link docs/reference/objects/product/modifier.md %}).
 
@@ -18,6 +18,7 @@ To display the deposit amount in Sites, note;
 - If a promotion is applied, the deposit applies to the promotional price. 
 - If the price is 0, `deposit.enabled` may return true, but it doesn't make sense to present a deposit price.
 - If the due date has passed (or is today), the method `deposit.enabled` will return false, you don't need to check for this.
+- You cannot access deposits directly through an extra, i.e. `extra.deposit` returns nil. It must be accessed through the parent product.
 
 Check for the deposit at the product level:
 
@@ -63,6 +64,8 @@ When displaying a series summary, the approach is similar (i.e. only the feature
 {% endif %}
 ```
 {% endraw %}
+
+> Note: Experiences in a series will all have 1 departure date. So `series.featured_variant.product.deposit.due_date` will return a date but this should not be shown in the series summary, as it will be the due date for the specific product rather than relating to the series generally.
 
 You may wish to display the deposit amount for each variant or extra when looping through them:
 {% raw %}

--- a/docs/pricing_and_payments/deposits.md
+++ b/docs/pricing_and_payments/deposits.md
@@ -15,7 +15,7 @@ A deposit is set at a product level and applies to all [variants]({% link docs/r
 To display the deposit amount in Sites, note;
 
 - Deposits can be set on both Experience and Accommodation product types, but cannot currently be displayed in Sites for Accommodation types. 
-- If a promotion is applied, the deposit applies to the promotional price. 
+- If a promotion is applied, the deposit applies to the promotional price.
 - If the price is 0, `deposit.enabled` may return true, but it doesn't make sense to present a deposit price.
 - If the due date has passed (or is today), the method `deposit.enabled` will return false, you don't need to check for this.
 - You cannot access deposits directly through an extra, i.e. `extra.deposit` returns nil. It must be accessed through the parent product.

--- a/docs/reference/objects/product/deposit.md
+++ b/docs/reference/objects/product/deposit.md
@@ -35,3 +35,23 @@ Example
 {{ deposit_price | money }}
 ```
 {% endraw %}
+
+
+## `deposit.due_date`
+{: .d-inline-block }
+Date
+{: .label .fs-1 }
+
+The date the final balance payment will be due, if this can be calculate and the deposit is enabled. This can be formatted with Liquid's [date filters](https://shopify.github.io/liquid/filters/date/). The Creator may have set this as a number of days relative to the experience or accommodation start date, or they may have selected a specific date from a calendar. They also may have not set a value, in which case a default of 60 days before start date is used.
+
+- When accessed through an [experience slot]({% link docs/reference/objects/product/experience_slot.md %}) it will return a date.
+- When accessed through a single slot experience it will return a date.
+- When accessed through a multislot experience or an accommodation, it will return nil.
+
+Example
+{% raw %}
+```liquid
+{{ deposit.due_date | date: "%Y-%m-%d" }}
+{% endif %}
+```
+{% endraw %}

--- a/docs/reference/objects/product/deposit.md
+++ b/docs/reference/objects/product/deposit.md
@@ -46,7 +46,7 @@ The date the final balance payment will be due, if this can be calculate and the
 
 - When accessed through an [experience slot]({% link docs/reference/objects/product/experience_slot.md %}) it will return a date.
 - When accessed through a single slot experience it will return a date.
-- When accessed through a multislot experience or an accommodation, it will return nil.
+- When accessed through a multislot experience or an accommodation, it will return `nil`.
 
 Example
 {% raw %}


### PR DESCRIPTION
New method incoming, [branch here](https://github.com/easolhq/easol/compare/main...sun-172-expose-deposit-due-date-information-to-frontend)
I will only merge these doc changes once that code is live.

So I used the following snippet to confirm that deposit isn't actually available on extras, because how the docs are written currently suggests they might be? Clearly hasn't been an issue until now, so just making you aware, feel free to revise the docs as you see fit to reflect these changes.

And if you want to checkout the Easol branch and use this to have a click test to confirm everything is as you would expect, please do 🙏 

```
{% for product in company.products %}
  <h4>product.name: {{ product.name }}</h4>
  <p>product.deposit.enabled: {{ product.deposit.enabled }}</p>
  <p>product.deposit.rate: {{ product.deposit.rate }}</p>
  <p>product.deposit.due_date: {{ product.deposit.due_date }}</p>
  
  <div style="background-color: var(--secondary);">
    <h5>Extras</h5>
    {% for extra in product.extras %}
      <p>extra.name: {{ extra.name }}</p>
      <p>extra.deposit.enabled: {{ extra.deposit.enabled }}</p>
      <p>extra.deposit.rate: {{ extra.deposit.rate }}</p>
      <p>extra.deposit.due_date: {{ extra.deposit.due_date }}</p>
    {% endfor %}
  </div>
  
  <div style="background-color: var(--secondary);">
    <h5>Variants</h5>
    {% for variant in product.variants %}
      <p>variant.name: {{ variant.name }}</p>
      <p>variant.deposit.enabled: {{ variant.deposit.enabled }}</p>
      <p>variant.deposit.rate: {{ variant.deposit.rate }}</p>
      <p>variant.deposit.due_date: {{ variant.deposit.due_date }}</p>
    {% endfor %}
  </div>
  
  <div style="background-color: var(--primary);">
    <h5>Slots</h5>
    {% assign product_id = product.id %}
    {% experience_slot_search product_id: product_id, page_size: 50 %}
      {% for item in result.items %}
        <p>item.start_on: {{ item.start_on | date: "%Y-%m-%d" }}</p>
        <p>item.deposit.enabled: {{ item.deposit.enabled }}</p>
        <p>item.deposit.rate: {{ item.deposit.rate }}</p>
        <p>item.deposit.due_date: {{ item.deposit.due_date }}</p>
      {% endfor %}
    {% endexperience_slot_search %}
  </div>
{% endfor %}
```