### PR TITLE
formatting: converting nil to `nil` for consistency

### DIFF
--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -31,7 +31,7 @@ string
 
 The end time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
 
-This will return nil if the experience does not have a start time.
+This will return `nil` if the experience does not have a start time.
 
 ## `slot.id`
 {: .d-inline-block }
@@ -52,7 +52,7 @@ The price of this variant on this slot in the current user's currency.
 number
 {: .label .fs-1 }
 
-The remaining stock for this variant on this slot. It will return nil if there is infinite stock.
+The remaining stock for this variant on this slot. It will return `nil` if there is infinite stock.
 
 ## `slot.shop_url`
 {: .d-inline-block }
@@ -82,4 +82,4 @@ string
 
 The start time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
 
-This will return nil if the experience does not have a start time.
+This will return `nil` if the experience does not have a start time.

--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -39,7 +39,7 @@ string
 
 The end time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
 
-This will return nil if the experience does not have a start time.
+This will return `nil` if the experience does not have a start time.
 
 ## `experience_slot.extras`
 {: .d-inline-block }
@@ -123,7 +123,7 @@ string
 
 The start time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
 
-This will return nil if the experience does not have a start time.
+This will return `nil` if the experience does not have a start time.
 
 ## `experience_slot.variants`
 {: .d-inline-block }

--- a/docs/reference/objects/product/variant/payment_plan.md
+++ b/docs/reference/objects/product/variant/payment_plan.md
@@ -21,7 +21,7 @@ The upfront payment for this payment plan, in the quantity of the
 smallest unit for this currency. (e.g. cents for USD, pence for GBP, yen
 for JPY etc.)
 
-This will be nil if there is no custom initial payment amount set.
+This will be `nil` if there is no custom initial payment amount set.
 In the case of no custom amount being set, the initial payment will be the total payment divided by the number of instalments.
 
 ## `payment_plan.is_initial_payment_fixed`


### PR DESCRIPTION
In most places throughout the docs nil is formatted like `nil`. I corrected it [here](https://github.com/easolhq/easolhq.github.io/pull/172/commits/c8112f97836c82596f816e5c85f401acee8460b2) as part of some new changes and thought to check/fix throughout the rest of the docs.