### PR TITLE
Document `Product#is_multi_slot_experience`

### DIFF
--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -211,6 +211,14 @@ boolean
 
 Returns a boolean indicating whether or not the product includes accommodation or is just a ticket.
 
+## `product.is_multi_slot_experience`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Returns a boolean indicating whether or not the product is an experience with
+multiple slots.
+
 ## `product.min_price`
 {: .d-inline-block }
 boolean


### PR DESCRIPTION
We've added this method to the ProductDrop as a convenience method for determining if a product is an experience with >1 slot.

### Implementation 

See https://github.com/easolhq/easol/pull/12539.