### PR TITLE
Add recommendation object documentation

### DIFF
--- a/docs/reference/objects/recommendation.md
+++ b/docs/reference/objects/recommendation.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Recommendation
+parent: Objects
+---
+
+# Recommendation
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+#### Attributes
+
+## `recommendation.name`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The name of the recommendation.
+
+## `recommendation.message`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The message of the recommendation.
+
+## `recommendation.expired`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether the recommendation has expired.
+Users can still visit the recommendation show page is the recommendation has expired, but they will not be able to book it.
+
+## `recommendation.user_email`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The guest email set on the recommendation.
+Note: This may not be the same as the user who books the recommendation.
+
+## `recommendation.booking`
+{: .d-inline-block }
+[CartDrop]({% link docs/reference/objects/cart/index.md %})
+{: .label .fs-1 }
+
+The booking associated with the recommendation.
+
+## `recommendation.hero_image`
+{: .d-inline-block }
+[Image]({% link docs/reference/objects/image.md %})
+{: .label .fs-1 }
+
+The hero image of the recommendation.
+
+## `recommendation.checkout_url`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+This url will direct the user to checkout in order to purchase the recommendation.

--- a/docs/theme_architecture/templates.md
+++ b/docs/theme_architecture/templates.md
@@ -60,6 +60,15 @@ The selection is passed via a single `item` [Modifier Selection]({% link docs/re
 
 Each selection page is automatically generated at `site.com/items/*booking-id*/selections` and can only be accessed by the customer to whose booking the selection applies.
 
+## Recommendation
+`Optional`
+
+The template is passed via a single `recommendation` [Recommendation]({% link docs/reference/objects/recommendation.md %}) object.
+
+The recommendation page is automatically generated at site.com/recommendations/*recommendation_slug* when a valid recommendation has been created.
+
+This template will only render if it has been configured on the associated site - otherwise, the default recommendation page will be rendered.
+
 ## Package booking
 `Optional`
 


### PR DESCRIPTION
We are adding a template to sites for the
recommendation #show page. In order to
support this we added a RecommendationDrop.

This documents the new object.

PR: https://github.com/easolhq/easol/pull/12795