### PR TITLE
docs: updating `field.required` to show it returns a boolean

### DIFF
--- a/docs/reference/objects/form/field/index.md
+++ b/docs/reference/objects/form/field/index.md
@@ -41,7 +41,7 @@ Returns the string that should be set as the name attribute, to ensure successfu
 
 ## `field.required`
 {: .d-inline-block }
-string
+boolean
 {: .label .fs-1 }
 
 Returns `true` or `false` depending on whether the field is required for successful form submission.


### PR DESCRIPTION
@eballantine sorry, totally missed this when reviewing [your PR](https://github.com/easolhq/easolhq.github.io/pull/181). `field.required` returns a `boolean` rather than a `string`, so just updating to represent that.