### PR TITLE
Adds documentation for product.company method [SCR-114]

### DIFF
--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -40,6 +40,13 @@ string
 
 The category the product belongs to.
 
+## `product.company`
+{: .d-inline-block }
+[Company]({% link docs/reference/objects/company.md %})
+{: .label .fs-1 }
+
+The company the product is associated with.
+
 ## `product.country`
 {: .d-inline-block }
 string


### PR DESCRIPTION
The ProductDrop can now return its Company so we document that here

![Screenshot 2024-03-27 at 11 41 43](https://github.com/easolhq/easolhq.github.io/assets/16126115/c8ad2eef-b244-4a0e-99b9-4431fb94a5d9)
