### PR TITLE
Docs for ExperienceSlotCalendar::Slot#product

### DIFF
--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -47,6 +47,13 @@ The ID of the experience slot.
 
 The price of this variant on this slot in the current user's currency.
 
+## `slot.product`
+{: .d-inline-block }
+[Product]({% link docs/reference/objects/product/index.md %})
+{: .label .fs-1 }
+
+The experience that this slot belongs to.
+
 ## `slot.remaining_stock`
 {: .d-inline-block }
 number


### PR DESCRIPTION
This is the docs for the Slot#product method introduced in https://github.com/easolhq/easol/pull/13083