### PR TITLE
fix: correcting type for `package_step.step_valid?`

### DIFF
--- a/docs/reference/objects/package/step.md
+++ b/docs/reference/objects/package/step.md
@@ -82,7 +82,7 @@ URL pointing to the next page of the booking journey. Navigating to this URL is 
 
 ## `package_step.step_valid?`
 {: .d-inline-block }
-`true` or `false`
+boolean
 {: .label .fs-1 }
 
 This will return `false` if the customer has not added enough elements to the cart to honour the requirements set by the creator for this step, and `true` if they have.


### PR DESCRIPTION
Brings this inline with the rest of our docs.

### Before
![CleanShot 2024-04-03 at 11 04 33](https://github.com/easolhq/easolhq.github.io/assets/12126304/32223177-24e0-4117-9dcd-5837d36f9d2d)

### After
![CleanShot 2024-04-03 at 11 04 51](https://github.com/easolhq/easolhq.github.io/assets/12126304/2fbabb2a-f8bb-41e0-ab8c-befabeaf6c55)
