### PR TITLE
Docs for page.params

### DIFF
--- a/docs/reference/objects/page.md
+++ b/docs/reference/objects/page.md
@@ -24,6 +24,16 @@ The site's domain.
 
 `=> example.com`
 
+## `page.params`
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+The query params included in the current URL.
+
+For example, given the URL https://my-url.com?page=4,
+using {% raw %}`{{page.params.page}}`{% endraw %} would return "4".
+
 ## `page.path`
 {: .d-inline-block }
 string


### PR DESCRIPTION
This adds documentation for the new `page.params` method. 

The corresponding Rails PR can be seen here https://github.com/easolhq/easol/pull/13219