### PR TITLE
Add documentation for new attributes in package and package step item

### DIFF
--- a/docs/carts/cart_interactions/add_packages.md
+++ b/docs/carts/cart_interactions/add_packages.md
@@ -19,6 +19,7 @@ This will add all of the package's included items to the cart.
 | `package[quantity]`                | The number of the packages to add to the cart at once. |
 | `package[start_date]`              | The customers selected start date for the package. (Only required if packages.requires_date is true)|
 | `package[start_time]`              | The customers selected start time for the package. (optional)|
+| `package[adult_count]`             | The number of adults for the package. (Only available for flexible adult count packages)|
 | `package[items][][id]`             | The ID of the package item for which to add modifiers. |
 | `package[items][][modifier_ids][]` | The ID of the modifier to add to the cart.             |
 
@@ -30,6 +31,9 @@ This will add all of the package's included items to the cart.
 {% form 'add_package_to_cart' %}
   <input name="package[id]" value="1" type="hidden" />
   <input name="package[quantity]" min="1" value="1" type="number" />
+  <input name="package[start_date]" type="date" />
+  <input name="package[start_time]" type="time" />
+  <input name="package[adult_count]" type="number" />
   <input type="submit" value="Add">
 {% endform %}
 ```

--- a/docs/carts/cart_interactions/add_packages.md
+++ b/docs/carts/cart_interactions/add_packages.md
@@ -17,6 +17,8 @@ This will add all of the package's included items to the cart.
 | ---------------------------------- | ------------------------------------------------------ |
 | `package[id]`                      | The ID of the package to add to the cart.              |
 | `package[quantity]`                | The number of the packages to add to the cart at once. |
+| `package[start_date]`              | The customers selected start date for the package. (Only required if packages.requires_date is true)|
+| `package[start_time]`              | The customers selected start time for the package. (optional)|
 | `package[items][][id]`             | The ID of the package item for which to add modifiers. |
 | `package[items][][modifier_ids][]` | The ID of the modifier to add to the cart.             |
 

--- a/docs/reference/objects/package.md
+++ b/docs/reference/objects/package.md
@@ -50,6 +50,16 @@ number
 The total price for the package represented in the sub-unit of the current
 customer's currency. e.g. considering the amount $19.50, it will return 1950.
 
+## `package.requires_date`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether the package requires a date to be selected when adding to the cart.
+A date field with the name `package[start_date]` will be required when adding
+the package to the cart, optionally with a `package[start_time]` field matching
+the format `HH:MM` can be added to the form.
+
 ## `package.price_per_person_fractional`
 {: .d-inline-block }
 number

--- a/docs/reference/objects/package/product.md
+++ b/docs/reference/objects/package/product.md
@@ -35,3 +35,10 @@ Array of [Variant]({% link docs/reference/objects/product/variant/index.md %})
 {: .label .fs-1 }
 
 The variants of the `package_product.product` that the creator has included in the package and are eligible for booking by the customer.
+
+## `package_product.items`
+{: .d-inline-block }
+Array of [Package Step Item]({% link docs/reference/objects/package/step/item.md %})
+{: .label .fs-1 }
+
+An array of package step items for the `package_product.product`.

--- a/docs/reference/objects/package/step/item.md
+++ b/docs/reference/objects/package/step/item.md
@@ -1,0 +1,38 @@
+---
+layout: default
+title: Package Step Item
+parent: Package Step Product
+---
+
+# Package Step Item
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+Represents a single item in a [package step]({% link docs/reference/objects/package/step.md %}).
+
+<br>
+
+#### Attributes
+
+
+## `item.variant`
+{: .d-inline-block }
+[Variant]({% link docs/reference/objects/product/variant/index.md %})
+{: .label .fs-1 }
+
+The variant for the item.
+
+## `item.requires_slot_selection`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether the item requires a slot selection.
+
+## `item.available_slots_for_selection`
+{: .d-inline-block }
+Array of [Experience Slot]({% link docs/reference/objects/product/experience_slot.md %})s
+{: .label .fs-1 }
+
+The available experience slots for the item. This will only be present if `requires_slot_selection` is `true`.


### PR DESCRIPTION
Here we document the changes made to packages regarding slot selection and available slots. https://github.com/easolhq/easol/pull/13133
As well as accepting adult count added here: https://github.com/easolhq/easol/pull/13240
We have recently introduced a new method on package called `items` which will replace `variants` for steps of type `experience` in order to support slot selection for multi date packages.