### PR TITLE
Document behaviour of menu/footer caching

### DIFF
--- a/docs/reference/objects/menu/index.md
+++ b/docs/reference/objects/menu/index.md
@@ -11,7 +11,7 @@ has_toc: false
 object
 {: .label .fs-1 }
 
-Menu templates define their own schema, in a similar way to blocks. All of the attributes defined on a menu's schema are made available via the `Menu` object.
+Menu templates define their own schema, in a similar way to blocks. All of the attributes defined on a menu's schema are made available via the `Menu` object. Also note, the menu is cached.
 
 For example, consider the following menu schema:
 

--- a/docs/site_navigation/footer.md
+++ b/docs/site_navigation/footer.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Footer Template
 Apart from the [main site navigation]({% link docs/site_navigation/header.md %}) the site can have a secondary navigation in the **footer template** (partials/footer/index.html). One can't be accessed from the other.
-The [footer]({% link docs/reference/objects/footer/index.md %}) is a special kind of [partial]({% link docs/theme_architecture/partials.md %}) which is rendered in all site pages, always at the end of the `body` tag. It contains a [schema]({% link docs/theme_architecture/blocks/schema/index.md %}) where [variables]({% link docs/theme_architecture/blocks/schema/variables/index.md %}) can be added, removed or edited. The footer template might be used to include additional [libraries]({% link docs/libraries/index.md %}).
+The [footer]({% link docs/reference/objects/footer/index.md %}) is a special kind of [partial]({% link docs/theme_architecture/partials.md %}) which is rendered in all site pages, always at the end of the `body` tag. It contains a [schema]({% link docs/theme_architecture/blocks/schema/index.md %}) where [variables]({% link docs/theme_architecture/blocks/schema/variables/index.md %}) can be added, removed or edited. The footer template might be used to include additional [libraries]({% link docs/libraries/index.md %}). Also note, the footer is cached.
 
 ## Common examples
 


### PR DESCRIPTION
Some Creators have wanted to be able to render a different menu depending on various page or cart attributes. This is not possible by default (nor in the footer) so we should document this so that; they realise what is possible ahead of development time, or they can more quickly debug when things are not updating.

Note; we have added a cached flag to headers to be used internally to turn off the default caching. We are not making this a standard option/feature without further consideration.