### PR TITLE
MICE-408 Docs for exposing package_booking (PackageBookingDrop) on CartItemDrop

### DIFF
--- a/docs/reference/objects/cart/cart_item.md
+++ b/docs/reference/objects/cart/cart_item.md
@@ -158,3 +158,12 @@ string
 {: .label .fs-1 }
 
 The name of the variant associated with the cart item.
+
+## `item.package_booking`
+{: .d-inline-block }
+[PackageBooking]({% link docs/reference/objects/package_booking.md %}).
+{: .label .fs-1 }
+
+The associated package booking if the item is being booked as part of a package.
+
+It will return `nil` if the item isn't part of a package.

--- a/docs/reference/objects/package_booking.md
+++ b/docs/reference/objects/package_booking.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Package Booking
+parent: Objects
+---
+
+# Package Booking
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+Provides information about a customer's choices made while booking a [package]({% link docs/reference/objects/package.md %}).
+
+<br>
+
+#### Attributes
+
+## `package_booking.id`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The unique id of the package booking.
+
+## `package_booking.package`
+{: .d-inline-block }
+[Package]({% link docs/reference/objects/package.md %}).
+{: .label .fs-1 }
+
+The package that the customer is booking.
+
+## `package_booking.adult_count`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The number of guests that the customer is booking the package for.
+
+## `package_booking.selected_start_date`
+{: .d-inline-block }
+Date
+{: .label .fs-1 }
+
+The customer's chosen date for the package.
+
+It will return `nil` if the customer hasn't chosen a date.
+
+## `package_booking.selected_start_time`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The customer's chosen time for the package. Formatted as "HH:MM", in 24-hour clock time, e.g. "09:30".
+
+It will return `nil` if the customer hasn't chosen a time.


### PR DESCRIPTION
Here are some documentation changes following the changes made in https://github.com/easolhq/easol/pull/13298. (Plus filling in some missing docs for package booking.)

