### PR TITLE
Fix docs re: caching the footer

### DIFF
--- a/docs/site_navigation/footer.md
+++ b/docs/site_navigation/footer.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Footer Template
 Apart from the [main site navigation]({% link docs/site_navigation/header.md %}) the site can have a secondary navigation in the **footer template** (partials/footer/index.html). One can't be accessed from the other.
-The [footer]({% link docs/reference/objects/footer/index.md %}) is a special kind of [partial]({% link docs/theme_architecture/partials.md %}) which is rendered in all site pages, always at the end of the `body` tag. It contains a [schema]({% link docs/theme_architecture/blocks/schema/index.md %}) where [variables]({% link docs/theme_architecture/blocks/schema/variables/index.md %}) can be added, removed or edited. The footer template might be used to include additional [libraries]({% link docs/libraries/index.md %}). Also note, the footer is cached.
+The [footer]({% link docs/reference/objects/footer/index.md %}) is a special kind of [partial]({% link docs/theme_architecture/partials.md %}) which is rendered in all site pages, always at the end of the `body` tag. It contains a [schema]({% link docs/theme_architecture/blocks/schema/index.md %}) where [variables]({% link docs/theme_architecture/blocks/schema/variables/index.md %}) can be added, removed or edited. The footer template might be used to include additional [libraries]({% link docs/libraries/index.md %}).
 
 ## Common examples
 


### PR DESCRIPTION
The [footer is not cached](https://github.com/easolhq/easol/blob/63ac4840d61ee63f85fd9d11ba27c1dd5a3a372c/app/models/site/footer.rb#L140-L141) the same way as [the menu is cached](https://github.com/easolhq/easol/blob/2f4c0c73073393446dd05c3b5360b420dc2f5d1a/app/models/site/menu.rb#L198-L199).
Apologies we previously assumed it was.