### PR TITLE
Add terms_and_conditions_url to recommendation object

### DIFF
--- a/docs/reference/objects/recommendation.md
+++ b/docs/reference/objects/recommendation.md
@@ -69,3 +69,11 @@ string
 {: .label .fs-1 }
 
 This url will direct the user to checkout in order to purchase the recommendation.
+
+## `recommendation.terms_and_conditions_url`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The URL of the recommendation's terms.
+If the recommendation has custom terms it will display those, otherwise it will default to the company's terms.


### PR DESCRIPTION
We're now exposing the terms_and_conditions_url on the recommendation object. See PR: https://github.com/easolhq/easol/pull/13473

This commits updates the docs to include that.

![Screenshot 2024-05-07 at 15 09 05](https://github.com/easolhq/easolhq.github.io/assets/10531930/72c39294-a83c-4498-ab9a-e7f4161df3ea)
