### PR TITLE
reflecting correct acceptance for id passed to `remove_line_item` form

### DIFF
--- a/docs/reference/tags/form_tags/remove_line_item/index.md
+++ b/docs/reference/tags/form_tags/remove_line_item/index.md
@@ -14,7 +14,7 @@ The tag can be used with a single line item or when iterating over a collection 
 {% raw %}
 ```liquid
 {% form 'remove_line_item' %}
-   <input name="items[]" value="**<variant.id or extra.id>**" type="hidden" />
+   <input name="items[]" value="**<cart_item.id>**" type="hidden" />
    <input type="submit" value="Remove" />
 {% endform %}
 ```


### PR DESCRIPTION
This form will only accept a `cart_item.id` and not a `variant.id` or `extra.id`. Confirmation from platform in [this thread](https://easolhq.slack.com/archives/C03HMNR7WN7/p1715176933843139).