### PR TITLE
Update the custom data documentation

### DIFF
--- a/docs/reference/objects/cart/custom_data.md
+++ b/docs/reference/objects/cart/custom_data.md
@@ -7,10 +7,22 @@ grand_parent: Objects
 
 # Custom data
 
-Used to display booking custom field values on a [cart object]({% link docs/reference/objects/cart/index.md %}).
+The custom data the creator has chosen to be visible for this [cart]({% link docs/reference/objects/cart/index.md %}) aka booking.
+Each custom data is its own array of 2 strings, the display name of the custom field & the value assigned to it. If the custom field is a checkbox, we only return the data when the checkbox is checked, with the value 'Yes'. If a Creator wants to display e.g. 'Includes a drink: true/false', they should use a multi-select data type with the options 'true' and 'false'.
 
-## `cart_drop.custom_data`
-{: .d-inline-block }
-array
-{: .label .fs-1 }
-custom_data returns an array of 2 things, the internal label & the value.
+##### input
+{% raw %}
+```liquid
+{% for custom_data in cart.custom_data %}
+  <p>{{ custom_data[0] }}: {{ custom_data[1] }}</p>
+{% endfor %}
+```
+{% endraw %}
+
+##### output
+{% raw %}
+```html
+  <p>Assigned tour guide: Ellie</p>
+  <p>Where to meet: October 10 2025, 12:15pm (local time) outside the Opera House.</p>
+```
+{% endraw %}

--- a/docs/reference/objects/cart/index.md
+++ b/docs/reference/objects/cart/index.md
@@ -27,10 +27,10 @@ The currency code associated with the cart.
 
 ## `cart.custom_data`
 {: .d-inline-block }
-An array of [Custom Data]({% link docs/reference/objects/cart/custom_data.md %})
+array of [Custom Data]({% link docs/reference/objects/cart/custom_data.md %})
 {: .label .fs-1 }
 
-An array containing [custom data]({% link docs/reference/objects/cart/custom_data.md %}) of booking custom fields with values.
+An array of [custom data]({% link docs/reference/objects/cart/custom_data.md %}) that the creator has chosen to be visible. For use in recommendation templates where the cart is the booking.
 
 ## `cart.subtotal`
 {: .d-inline-block }


### PR DESCRIPTION
Following from this change https://github.com/easolhq/easol/pull/14163

We have swapped from exposing the internal label to the display name. I've also added a small example of how to use this, and a nod towards the visible/invisible nature of these fields.

![Screenshot 2024-07-08 at 11 47 29](https://github.com/easolhq/easolhq.github.io/assets/78875971/aa209e33-9107-49c4-8d51-c65039adf37c)
![Screenshot 2024-07-08 at 11 48 09](https://github.com/easolhq/easolhq.github.io/assets/78875971/d052d907-d3c8-4b05-bf68-f9ef1e9e91d5)
