### PR TITLE
Mice 954 expose can be booked by current user on recommendationdrop

### DIFF
--- a/docs/reference/objects/recommendation.md
+++ b/docs/reference/objects/recommendation.md
@@ -11,19 +11,19 @@ object
 
 #### Attributes
 
-## `recommendation.name`
+## `recommendation.cart`
+{: .d-inline-block }
+[CartDrop]({% link docs/reference/objects/cart/index.md %})
+{: .label .fs-1 }
+
+The cart associated with the recommendation.
+
+## `recommendation.checkout_url`
 {: .d-inline-block }
 string
 {: .label .fs-1 }
 
-The name of the recommendation.
-
-## `recommendation.message`
-{: .d-inline-block }
-string
-{: .label .fs-1 }
-
-The message of the recommendation.
+This url will direct the user to checkout in order to purchase the recommendation.
 
 ## `recommendation.expired`
 {: .d-inline-block }
@@ -33,14 +33,6 @@ boolean
 Whether the recommendation has expired.
 Users can still visit the recommendation page if the recommendation has expired, but they will not be able to book it.
 
-## `recommendation.user_email`
-{: .d-inline-block }
-string
-{: .label .fs-1 }
-
-The guest email set on the recommendation.
-Note: This may not be the same as the user who books the recommendation.
-
 ## `recommendation.guest_count`
 {: .d-inline-block }
 string
@@ -49,13 +41,6 @@ string
 The guest count set on the recommendation.
 Note: This is an optional field and may not be set.
 
-## `recommendation.cart`
-{: .d-inline-block }
-[CartDrop]({% link docs/reference/objects/cart/index.md %})
-{: .label .fs-1 }
-
-The cart associated with the recommendation.
-
 ## `recommendation.hero_image`
 {: .d-inline-block }
 [Image]({% link docs/reference/objects/image.md %})
@@ -63,12 +48,19 @@ The cart associated with the recommendation.
 
 The hero image of the recommendation.
 
-## `recommendation.checkout_url`
+## `recommendation.message`
 {: .d-inline-block }
 string
 {: .label .fs-1 }
 
-This url will direct the user to checkout in order to purchase the recommendation.
+The message of the recommendation.
+
+## `recommendation.name`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The name of the recommendation.
 
 ## `recommendation.terms_and_conditions_url`
 {: .d-inline-block }
@@ -77,3 +69,11 @@ string
 
 The URL of the recommendation's terms.
 If the recommendation has custom terms it will display those, otherwise it will default to the company's terms.
+
+## `recommendation.user_email`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The guest email set on the recommendation.
+Note: This may not be the same as the user who books the recommendation.

--- a/docs/reference/objects/recommendation.md
+++ b/docs/reference/objects/recommendation.md
@@ -18,6 +18,13 @@ object
 
 The cart associated with the recommendation.
 
+## `recommendation.can_change_currency`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether the current user is able to change the currency on this recommendation. This can be used to conditionally show the currency switcher on the recommendation page.
+
 ## `recommendation.checkout_url`
 {: .d-inline-block }
 string


### PR DESCRIPTION
We recently add a `can_change_currency` method onto the RecommendationDrop in https://github.com/easolhq/easol/pull/14596

This PR adds the documentation for the method. The method can be used to conditionally show the currency switcher, e.g.

```
{% if recommendation.can_change_currency %}
  <div class="{{ id }}__currency-switcher">
    {% currency_switcher %}
  </div>
{% endif %}
```