### PR TITLE
Update Docs To Reference The Gratuity Drop

### DIFF
--- a/docs/reference/objects/adjustment/gratuity.md
+++ b/docs/reference/objects/adjustment/gratuity.md
@@ -1,0 +1,26 @@
+---
+layout: default
+title: Gratuity
+parent: Objects
+---
+
+# Gratuity
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+#### Attributes
+
+## `gratuity.percentage`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The percentage of the cart total that the gratuity takes up. This excludes insurance and fees.
+
+## `gratuity.amount`
+{: .d-inline-block }
+integer
+{: .label .fs-1 }
+
+The total amount of the gratuity returned in the subunit amount of the customer's currency . e.g. £5 is 500

--- a/docs/reference/objects/cart/index.md
+++ b/docs/reference/objects/cart/index.md
@@ -32,6 +32,13 @@ array of [Custom Data]({% link docs/reference/objects/cart/custom_data.md %})
 
 An array of [custom data]({% link docs/reference/objects/cart/custom_data.md %}) that the creator has chosen to be visible. For use in recommendation templates where the cart is the booking.
 
+## `cart.gratuity`
+{: .d-inline-block }
+[Gratuity]({% link docs/reference/objects/adjustment/gratuity.md %})
+{: .label .fs-1 }
+
+The [gratuity]({% link docs/reference/objects/adjustment/gratuity.md %}) set for the current cart.
+
 ## `cart.subtotal`
 {: .d-inline-block }
 number


### PR DESCRIPTION
You can now retrieve information about the gratuity for an order from the cart drop. 

![Screenshot 2024-09-27 at 15 30 23](https://github.com/user-attachments/assets/1ec5b316-625a-41ab-8012-3f8b305c6a95)

I've also added a new page for the gratuity drop object

