### PR TITLE
feat: update package payment plan info

### DIFF
--- a/docs/reference/objects/package.md
+++ b/docs/reference/objects/package.md
@@ -96,6 +96,13 @@ string
 
 The copy to display when the package is off sale.
 
+## `package.payment_plan`
+{: .d-inline-block }
+[Payment Plan]({% link docs/reference/objects/product/variant/payment_plan.md %})
+{: .label .fs-1 }
+
+If the package is custom priced and has a payment plan associated with it, this will return that payment plan. The payment plan won’t be returned if the instalment schedule cannot be completed before the start date of the package.
+
 ## `package.state`
 {: .d-inline-block }
 string


### PR DESCRIPTION
We recently shipped [a change](https://github.com/easolhq/easol/pull/14777) to expose payment plan information on packages. 

This PR updates the docs in accordance with this change.