### PR TITLE
refactor: update `available_slots_for_selection` documentation

### DIFF
--- a/docs/reference/objects/package/step/item.md
+++ b/docs/reference/objects/package/step/item.md
@@ -28,11 +28,14 @@ The variant for the item.
 boolean
 {: .label .fs-1 }
 
-Whether the item requires a slot selection.
+Whether the item requires the customer to select a slot.
 
 ## `item.available_slots_for_selection`
 {: .d-inline-block }
 Array of [Experience Slot]({% link docs/reference/objects/product/experience_slot.md %})s
 {: .label .fs-1 }
 
-The available experience slots for the item. If `requires_slot_selection` is `false`, then this will return an array with a single experience slot.
+If the item requires the customer to select a slot, this will return an array of available experience slots. If the item does not require the customer to select a slot, this will return an array with a single experience slot.
+
+In the event that there are no available slots, the array will be empty.
+


### PR DESCRIPTION
The current phrasing of the docs suggests that `available_slots_for_selection` and `requires_slot_selection` are coupled/dependent on each other.

But the actual drop code suggestions that the query associated with `available_slots_for_selection` is always executed - the only difference is that for items that don't require the customer to select from a range of available times, the maximum number of slots in the array will always be 1.

In the themes, we were previously checking that `requires_slot_selection` was true before checking slot availability on the assumption that `available_slots_for_selection` would only be executed for items requiring slot selection. If there were no slots returned, we'd set the item to sold out. But this meant that we weren't checking that slots were actually available for items with only one automatically-assigned slot, which meant that items were showing as available but actually didn't have the slot behind the scenes. 

We've updated this to check `available_slots_for_selection.size` for all items now (removing the additional check for `requires_slot_selection`), which seems to have done the trick!

This update tweaks the phrasing to make it clearer how these two drops work and what should be expected as a return. @murraycatto , I'm adding you as the reviewer as you wrote the initial docs, so please let me know if I've misunderstood something here! ❤️ 