### PR TITLE
fix: renaming `pagination` to `paginate` to match drop

### DIFF
--- a/docs/experience_slot_search/index.md
+++ b/docs/experience_slot_search/index.md
@@ -10,7 +10,7 @@ has_toc: false
 
 Experience slot search enables you to filter a Creator's experiences with a separate result for each departure date of each experience.
 
-The experience slot search is executed using the [experience_slot_search tag]({% link docs/reference/tags/experience_slot_search_tag/index.md %}). The tag returns an `items` array of [ExperienceSlots]({% link docs/reference/objects/product/experience_slot.md %}), a `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object, a `search` [Search]({% link docs/reference/objects/search_query.md %}) object, and an `available_months` array of Date objects (see [Liquid documentation for Dates](https://shopify.github.io/liquid/filters/date)).
+The experience slot search is executed using the [experience_slot_search tag]({% link docs/reference/tags/experience_slot_search_tag/index.md %}). The tag returns an `items` array of [ExperienceSlots]({% link docs/reference/objects/product/experience_slot.md %}), a `paginate` [Paginate]({% link docs/reference/objects/paginate.md %}) object, a `search` [Search]({% link docs/reference/objects/search_query.md %}) object, and an `available_months` array of Date objects (see [Liquid documentation for Dates](https://shopify.github.io/liquid/filters/date)).
 
 The experience slot search will only return public, published dates i.e. where the experience is published and has not been marked as private under 'Manage product availability' in the product settings.
 
@@ -41,7 +41,7 @@ http://beyondadventures.com/search?search[name]=beyond&search[departure_date][gr
 ## Pagination
 The results of the search are paginated to speed up page load, you can define the number of results displayed per page using the [page_size]({% link docs/experience_slot_search/parameters.md %}#page_size) parameter.
 
-You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
+You can enable customers to move between the results pages using the `paginate` [Paginate]({% link docs/reference/objects/paginate.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
 
 You can assign the value of a Liquid variable to `page_size`.
 

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -14,7 +14,7 @@ Product search enables you to filter a Creator's experiences, for example, you c
 - Return products for a specific date range or year
 - Sort the results by departure date
 
-The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object and a `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
+The product search is executed using the [product_search tag]({% link docs/reference/tags/product_search/index.md %}). The tag returns an `items` array of [products]({% link docs/reference/objects/product/index.md %}), a `paginate` [Paginate]({% link docs/reference/objects/paginate.md %}) object and a `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
 
 The product search will only return public, published products i.e. experiences which are published and have not been marked as private under 'Manage product availability' in the product settings.
 
@@ -49,7 +49,7 @@ http://beyondadventures.com/search?search[name]=beyond&search[departure_date][gr
 ## Pagination
 The results of the search are paginated to speed up page load, you can define the number of results displayed per page using the [page_size]({% link docs/product_search/parameters.md %}#page_size) parameter.
 
-You can enable customers to move between the results pages using the `paginate` [Pagination]({% link docs/reference/objects/pagination.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
+You can enable customers to move between the results pages using the `paginate` [Paginate]({% link docs/reference/objects/paginate.md %}) object. The [default_pagination]({% link docs/reference/filters/pagination.md %}) filter can be used to return a complete pagination UI.
 
 You can assign the value of a Liquid variable to `page_size`.
 

--- a/docs/reference/filters/pagination.md
+++ b/docs/reference/filters/pagination.md
@@ -7,7 +7,7 @@ grand_parent: Reference
 
 # default_pagination
 
-Provides complete pagination HTML for a supplied [Pagination]({%link docs/reference/objects/pagination.md %}) object. It should be supplied in this format: 
+Provides complete pagination HTML for a supplied [Paginate]({% link docs/reference/objects/paginate.md %}) object. It should be supplied in this format: 
 
 {% raw %}
 ```liquid

--- a/docs/reference/objects/paginate.md
+++ b/docs/reference/objects/paginate.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Pagination
+title: Paginate
 parent: Objects
 ---
 

--- a/docs/reference/objects/pagination.md
+++ b/docs/reference/objects/pagination.md
@@ -11,14 +11,14 @@ object
 
 #### Attributes
 
-## `pagination.collection_size`
+## `paginate.collection_size`
 {: .d-inline-block }
 number
 {: .label .fs-1 }
 
 The total number of items returned in the collection.
 
-## `pagination.current_offset`
+## `paginate.current_offset`
 {: .d-inline-block }
 number
 {: .label .fs-1 }
@@ -26,42 +26,42 @@ number
 The number of items on previous pages, i.e. that we've had to skip to get to the current page.
 If our collection was `[1,2,3,4]` and the offset was 2 then our result would be `[3,4]`.
 
-## `pagination.current_page`
+## `paginate.current_page`
 {: .d-inline-block }
 number
 {: .label .fs-1 }
 
 The page number currently being displayed. This is driven by a query param e.g. `url.com/?page=3`.
 
-## `pagination.next`
+## `paginate.next`
 {: .d-inline-block }
 string
 {: .label .fs-1 }
 
 The pagination link to go to the next page, if there is no next page this won't be set.
 
-## `pagination.page_count`
+## `paginate.page_count`
 {: .d-inline-block }
 number
 {: .label .fs-1 }
 
 The total number of pages.
 
-## `pagination.page_size`
+## `paginate.page_size`
 {: .d-inline-block }
 number
 {: .label .fs-1 }
 
 The maximum number of items displayed on each page.
 
-## `pagination.parts`
+## `paginate.parts`
 {: .d-inline-block }
 array of strings
 {: .label .fs-1 }
 
 An array of pagination links which represent links to specific page numbers of the collection, this handles abbreviation to an ellipsis if the number of pages is too high.
 
-## `pagination.previous`
+## `paginate.previous`
 {: .d-inline-block }
 string
 {: .label .fs-1 }

--- a/docs/theme_architecture/templates.md
+++ b/docs/theme_architecture/templates.md
@@ -16,7 +16,7 @@ The blog overview template consists of an `index.html` and an `index.css` file.
 
 Blog posts are passed via a `posts` array of [Post]({% link docs/reference/objects/blog_post.md %}) objects.
 
-The blog overview page automatically implements pagination, displaying 12 posts per page. A [Pagination]({% link docs/reference/objects/pagination.md %}) object can be accessed via `paginate` in the `index.html` code to generate links to other pages, display page counts etc.
+The blog overview page automatically implements pagination, displaying 12 posts per page. A [Paginate]({% link docs/reference/objects/paginate.md %}) object can be accessed via `paginate` in the `index.html` code to generate links to other pages, display page counts etc.
 
 The blog overview page is automatically generated at `site.com/blog`.
 


### PR DESCRIPTION
I noticed the drop is `paginate` but the docs say it's `pagination`. I didn't update the name of the object itself, as unsure this makes sense to do plurally, so there's a bit of inconsistency now - but at least the docs are accurate and represent how to actually access this drop.