### PR TITLE
Start the Search Params section for step product search tag

### DIFF
--- a/docs/reference/tags/package_step_product_search_tag/index.md
+++ b/docs/reference/tags/package_step_product_search_tag/index.md
@@ -62,6 +62,12 @@ The package step product search tag executes a search on the given step's listab
 
 The tag returns an `items` array and a `Paginate` pagination object to the block passed in, the items array represents 1 page of the results from the search.
 
+## Search Params
+
+#### include_organisation_products
+
+This allows you to find the step products if the current package step is associated with a company that is different to the company for the current site, but they are linked by the same organisation. e.g. `include_organisation_products: true`
+
 ## Pagination
 
 The results of this search are paginated for performance reasons.


### PR DESCRIPTION
Once we have more of the search functionality merged, we'll update this section to be more descriptive about how you can search and with what parameters - but right now you can just pass `include_organisation_products` to the tag in order to find the step if the site is in a different organisation company.