### PR TITLE
Document total_off_platform_fee methods for Cart and CartItem

### DIFF
--- a/docs/reference/objects/cart/cart_item.md
+++ b/docs/reference/objects/cart/cart_item.md
@@ -137,7 +137,14 @@ The minimum amount to be paid for the item at checkout. If no deposit is enabled
 number
 {: .label .fs-1 }
 
-The booking fee amount for the item returned as a fractional in the sub-unit of the current customer's currency.
+The booking fee amount for the item returned as a fractional in the sub-unit of the current customer's currency. Does not include off-platform fees.
+
+## `item.total_off_platform_fee`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The off-platform booking fee amount for the item returned as a fractional in the sub-unit of the current customer's currency.
 
 ## `item.total_guests`
 {: .d-inline-block }

--- a/docs/reference/objects/cart/index.md
+++ b/docs/reference/objects/cart/index.md
@@ -58,7 +58,14 @@ The amount of the cart after all price reductions have been applied. This is ret
 number
 {: .label .fs-1 }
 
-The booking fee amount returned as a fractional in the sub-unit of the current customer's currency.
+The booking fee amount returned as a fractional in the sub-unit of the current customer's currency. Does not include off-platform fees.
+
+## `cart.total_off_platform_fee`
+{: .d-inline-block }
+number
+{: .label .fs-1 }
+
+The off-platform booking fee amount returned as a fractional in the sub-unit of the current customer's currency.
 
 ## `cart.total_price_reduction`
 {: .d-inline-block }


### PR DESCRIPTION
Both methods do essentially the same thing, return the total off-platform booking fees associated with an order.