### PR TITLE
Swan 246 `remaining_stock` methods don't include things marked as sold out

### DIFF
--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -59,7 +59,7 @@ The experience that this slot belongs to.
 number
 {: .label .fs-1 }
 
-The remaining stock for this variant on this slot. It will return `nil` if there is infinite stock.
+The remaining stock for this variant on this slot. It will return 0 if this variant on this slot is manually marked as 'Sold Out'. It will return `nil` if there is infinite stock.
 
 ## `slot.shop_url`
 {: .d-inline-block }

--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -93,7 +93,7 @@ The product that the date belongs to.
 number
 {: .label .fs-1 }
 
-The sum of remaining stock for a date's variants. If any of the variants have infinite stock this will return `nil`.
+The sum of remaining stock for a date's variants. If any of the variants for this slot are manually marked as 'Sold Out', they will contribute 0 towards this value. If any of the variants have infinite stock this will return `nil`.
 
 ## `experience_slot.shop_url`
 {: .d-inline-block }

--- a/docs/reference/objects/product/extra.md
+++ b/docs/reference/objects/product/extra.md
@@ -198,7 +198,7 @@ The extra's current active [promotion]({% link docs/reference/objects/product/pr
 number
 {: .label .fs-1 }
 
-The remaining stock for the extra, if the extra has unlimited inventory this will return `nil`.
+The remaining stock for the extra. If the extra is manually marked as 'Sold Out' this will return 0. If the extra has unlimited inventory this will return `nil`.
 - When accessed through an [experience slot]({% link docs/reference/objects/product/experience_slot.md %}), it will return the remaining stock for the extra on the given slot.
 - When accessed independently or through a product, it will return the sum total of remaining stock for the extra across all upcoming slots.
 

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -272,7 +272,7 @@ The products overview [image]({% link docs/reference/objects/image.md %}).
 number
 {: .label .fs-1 }
 
-The sum of remaining stock for a product's variants, if any of the variants have infinite stock this will return `nil`.
+The sum of remaining stock for a product's variants. If any variants are manually marked as 'Sold Out', they will contribute 0 towards this value. If any of the variants have infinite stock this will return `nil`.
 If the product is an experience with multiple slots, this returns the sum total of remaining stock for all variants across all upcoming slots.
 
 ## `product.schedule`

--- a/docs/reference/objects/product/modifier.md
+++ b/docs/reference/objects/product/modifier.md
@@ -189,7 +189,7 @@ e.g. considering the amount $19.50, it will return 1950.
 number
 {: .label .fs-1 }
 
-The remaining stock for the modifier. If the modifier has unlimited inventory this will return `nil`.
+The remaining stock for the modifier. If the modifier has been manually marked as 'Sold Out, this will return 0. If the modifier has unlimited inventory this will return `nil`.
 - When accessed through an [experience slot]({% link docs/reference/objects/product/experience_slot.md %}), it will return the remaining stock for the modifier on the given slot.
 - When accessed independently or through a product, it will return the sum total of remaining stock for the modifier across all upcoming slots.
 

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -239,7 +239,7 @@ The variant's current active [promotion]({% link docs/reference/objects/product/
 number
 {: .label .fs-1 }
 
-The remaining stock for the variant, if the variant has infinite stock this will return `nil`.
+The remaining stock for the variant. If the variant has been manually marked as 'Sold Out' this will return 0. If the variant has infinite stock this will return `nil`.
 - When accessed through an [experience slot]({% link docs/reference/objects/product/experience_slot.md %}), it will return the remaining stock for the variant on the given slot.
 - When accessed independently or through a product, it will return the sum total of remaining stock for the variant across all upcoming slots.
 

--- a/docs/reference/tags/package_availability_tag/index.md
+++ b/docs/reference/tags/package_availability_tag/index.md
@@ -39,7 +39,7 @@ The `package_availability` tag returns an object with the package availability a
 boolean
 {: .label .fs-1 }
 
-Whether the package is avaialable or not. A package will be available when all its included items and required steps items (if any) have availability on the specified date and the variants with availabilty will have enough stock to accomodate the specified adult count based on the quantity strategy chosen for that item when the package has been put toghether.
+Whether the package is available or not. A package will be available when all its included items and required steps items (if any) have availability on the specified date and the variants with availabilty will have enough stock to accommodate the specified adult count based on the quantity strategy chosen for that item when the package has been put toghether.
 
 - If package is fixed date, all the slots need to have enough availability given the adult_count.
 - If package is multi_date, there needs to be at least one available slot for each included item and each required step.
@@ -61,7 +61,7 @@ It's possible to use any of the following attributes in the package availability
 
 ### adult_acount
 The number of guests used to look up the package availability.
-e.g If passed "3", the package avaialabilty tag will use return avaialability information based on whether the package has enough stock to acommodate 3 guests on the given `start_date` and `start_time`
+e.g If passed "3", the package avaialabilty tag will use return avaialability information based on whether the package has enough stock to accommodate 3 guests on the given `start_date` and `start_time`
 
 ### start_date
 The date the package used to look up the package availability.


### PR DESCRIPTION
We've merged a change that affects how some stock methods consider 'marked as sold out'. PR: https://github.com/easolhq/easol/pull/15638

Sites use `_for_customers` stock methods which we introduced to handle timed baskets, however we're further updating them to say anything marked as sold out has 0 stock available to customers. This PR updates site docs to explain this.

