### PR TITLE
Update docs for url method on link

### DIFF
--- a/docs/reference/objects/link.md
+++ b/docs/reference/objects/link.md
@@ -71,4 +71,4 @@ The path of the URL for this link.
 string
 {: .label .fs-1 }
 
-The full URL for the link.
+Returns either the relative path to the linked resource, or a full URL if it's a static link.


### PR DESCRIPTION
Following up on https://github.com/easolhq/easol/pull/15683, we update the docs for the link drop.