### PR TITLE
Document FeeItemRate and TaxItemRate drops

### DIFF
--- a/docs/reference/objects/product/variant/fee_item_rate.md
+++ b/docs/reference/objects/product/variant/fee_item_rate.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Fee Item Rate
+parent: Variant
+grand_parent: Product
+---
+
+# Fee item rate
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+Represents an instance of a fee being applied to a variant. For example, if
+there's a cleaning fee of $50 applied to a variant and a booking fee of 5%,
+there would be two fee item rates against the variant representing each fee.
+
+#### Attributes
+
+## `fee_item_rate.applies`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+A string representing the way this fee applies to the variant based on it's
+guest and duration application strategies. This will be one of the following.
+
+- Per item, per stay
+- Per item, per night
+- Per guest, per stay
+- Per guest, per night
+
+## `fee_item_rate.description`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+A description of the fee item rate.
+
+If the fee is an amount, this will be the amount of the fee in the current
+currency of the cart. If no currency is available this will return the amount
+in the creator's home currency. This amount will be formatted as a string with
+the currency symbol, e.g. "$10.00".
+
+If the fee is a percentage, this will be a formatted string of the percentage
+of the fee, e.g. "20%".
+
+## `fee_item_rate.off_platform`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether or not this fee is a fee collected off of the Easol platform.
+
+## `fee_item_rate.fee_name`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The name of the fee being applied, e.g. "Cleaning fee" or "Booking fee".

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -66,6 +66,15 @@ Deprecated, the deposit should be calculated in Liquid, using a mixture of the `
 ```
 {% endraw %}
 
+## `variant.fees`
+{: .d-inline-block }
+array of [fee item rate]({% link docs/reference/objects/product/variant/fee_item_rate.md %})s
+{: .label .fs-1 }
+
+Returns an array of [fee item rates]({% link
+docs/reference/objects/product/variant/fee_item_rate.md %}) that apply to this
+variant.
+
 ## `variant.has_infinite_stock`
 {: .d-inline-block }
 boolean
@@ -275,3 +284,12 @@ The type of the variant, one of `experience_variant` or `accommodation_variant`.
 Check what other methods you can call on this drop according to their type,
 [Experience Variant]({% link docs/reference/objects/product/variant/experience_variant/index.md %}),
 [Accommodation Variant]({% link docs/reference/objects/product/variant/accommodation_variant/index.md %}).
+
+## `variant.taxes`
+{: .d-inline-block }
+array of [tax item rate]({% link docs/reference/objects/product/variant/tax_item_rate.md %})s
+{: .label .fs-1 }
+
+Returns an array of [tax item rates]({% link
+docs/reference/objects/product/variant/tax_item_rate.md %}) that apply to this
+variant.

--- a/docs/reference/objects/product/variant/tax_item_rate.md
+++ b/docs/reference/objects/product/variant/tax_item_rate.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Tax Item Rate
+parent: Variant
+grand_parent: Product
+---
+
+# Tax item rate
+{: .d-inline-block }
+object
+{: .label .fs-1 }
+
+Represents an instance of a tax being applied to a variant. For example, if 20%
+VAT is applied a variant as well as a city tax of 5%, there would be two tax
+item rates against the variant representing each tax.
+
+#### Attributes
+
+## `tax_item_rate.applies`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+A string representing the way this tax applies to the variant based on it's
+guest and duration application strategies. This will be one of the following.
+
+- Per item, per stay
+- Per item, per night
+- Per guest, per stay
+- Per guest, per night
+
+## `tax_item_rate.description`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+A description of the tax item rate.
+
+If the tax is an amount, this will be the amount of the tax in the current
+currency of the cart. If no currency is available this will return the amount
+in the creator's home currency. This amount will be formatted as a string with
+the currency symbol, e.g. "$10.00".
+
+If the tax is a percentage, this will be a formatted string of the percentage
+of the tax, e.g. "20%".
+
+## `tax_item_rate.off_platform`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Whether or not this tax is a tax collected off of the Easol platform.
+
+## `tax_item_rate.tax_name`
+{: .d-inline-block }
+string
+{: .label .fs-1 }
+
+The name of the tax being applied, e.g. "VAT" or "New York State Tax".


### PR DESCRIPTION
These drops are used to represent an instance of a fee or tax rate being applied to a variant.

Both are exposed by way of the VariantDrop `fees` and `taxes` methods.