### PR TITLE
Remove `can_change_currency` from Recommendation documentation

### DIFF
--- a/docs/reference/objects/recommendation.md
+++ b/docs/reference/objects/recommendation.md
@@ -18,13 +18,6 @@ object
 
 The cart associated with the recommendation.
 
-## `recommendation.can_change_currency`
-{: .d-inline-block }
-boolean
-{: .label .fs-1 }
-
-Whether the current user is able to change the currency on this recommendation. This can be used to conditionally show the currency switcher on the recommendation page.
-
 ## `recommendation.checkout_url`
 {: .d-inline-block }
 string


### PR DESCRIPTION
The `can_change_currency` option was been removed from the backend API in [this commit](https://github.com/easolhq/easol/pull/14969/commits/3471da773e8e63cc296c0a5eb134cee1641427b3), so removing it from the documentation to avoid confusion.