### PR TITLE
Document `experience_variant.pricing_strategy` attribute

### DIFF
--- a/docs/reference/objects/product/variant/experience_variant/index.md
+++ b/docs/reference/objects/product/variant/experience_variant/index.md
@@ -43,6 +43,20 @@ with the caveat that if the experience variant is accessed through an
 docs/reference/objects/product/variant/payment_plan.md %}) will only be
 returned if the last payment date is before the slot's `start_on`.
 
+## `experience_variant.pricing_strategy_per_item`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Reflects the creator's chosen pricing strategy for this variant. If true, this variant's price is determined by the price tier configured for the chosen occupancy.
+
+## `experience_variant.pricing_strategy_per_person`
+{: .d-inline-block }
+boolean
+{: .label .fs-1 }
+
+Reflects the creator's chosen pricing strategy for this variant. If true, this variant's price is proportional to the chosen occupancy, with the proportional increase determined by the configured price tiers.
+
 ## `experience_variant.type`
 {: .d-inline-block }
 string

--- a/docs/reference/objects/product/variant/index.md
+++ b/docs/reference/objects/product/variant/index.md
@@ -128,8 +128,10 @@ The initial stock for the variant, if the variant has unlimited inventory this w
 {: .d-inline-block }
 boolean
 {: .label .fs-1 }
+deprecated
+{: .label .fs-1 .label-red .ml-0 .mt-0 }
 
-Returns `true` if the variant is priced per person.
+Deprecated. New sites should avoid using this method; it is being kept for backwards compatibility only.
 
 ## `variant.modifier_groups`
 {: .d-inline-block }


### PR DESCRIPTION
Context: https://linear.app/easol/issue/POS-8/fe-need-to-be-able-to-determine-if-variant-is-priced-using-the-per#comment-50f6fba5

Related: https://github.com/easolhq/easol/pull/16767