### PR TITLE
[POS-196] Docs reflect the correct formatting for start and end time

### DIFF
--- a/docs/reference/objects/experience_slot_calendar/slot.md
+++ b/docs/reference/objects/experience_slot_calendar/slot.md
@@ -29,7 +29,7 @@ The date the slot ends on. This can then be used in conjunction with Liquid's [b
 string
 {: .label .fs-1 }
 
-The end time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
+The end time for this slot as a string in the hour and minute format, i.e. “11:00”
 
 This will return `nil` if the experience does not have a start time.
 
@@ -87,6 +87,6 @@ The date the slot starts on. This can then be used in conjunction with Liquid's 
 string
 {: .label .fs-1 }
 
-The start time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
+he start time for this slot as a string in the hour and minute format, i.e. “11:00”
 
 This will return `nil` if the experience does not have a start time.

--- a/docs/reference/objects/product/experience_slot.md
+++ b/docs/reference/objects/product/experience_slot.md
@@ -37,7 +37,7 @@ The date the slot ends on. This can then be used in conjunction with Liquid's [b
 string
 {: .label .fs-1 }
 
-The end time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
+The end time for this slot as a string in the hour and minute format, i.e. “11:00”
 
 This will return `nil` if the experience does not have a start time.
 
@@ -121,7 +121,7 @@ The date the slot starts on. This can then be used in conjunction with Liquid's 
 string
 {: .label .fs-1 }
 
-The start time for this slot as a formatted time string in the current user's locale. For example, "11:00" for English or "11:00AM" for American English.
+The start time for this slot as a string in the hour and minute format, i.e. “11:00”
 
 This will return `nil` if the experience does not have a start time.
 


### PR DESCRIPTION
We've updated these method in
https://github.com/easolhq/easol/pull/16910 so we're now updating the docs to reflect the exact formating the experience slot drop will return those.