### PR TITLE
Update variant_pricing tag documentation

### DIFF
--- a/docs/reference/tags/variant_pricing/index.md
+++ b/docs/reference/tags/variant_pricing/index.md
@@ -66,6 +66,7 @@ Parameter | Description | Required
 `adult_count` | Number of guests to consider in price calculation | Yes
 `start_on` | Check-in date to consider in price calculation | If rendering for an Accommodation Variant
 `end_on` | Check-in date to consider in price calculation | If rendering for an Accommodation Variant
+`include_fees` | Option to include booking fees and custom on platform fees in the price | No
 
 ## Bootstrapping and fetching new prices
 
@@ -133,5 +134,22 @@ you might hook onto the relevant elements' events:
 
       variantPricingTag.dataset.variantPricingEndOnValue = e.target.value
     })
+
+{% endraw %}
+
+
+## Consideration with packages
+
+When this tag is used in the context of a package step, the user may need to
+choose from a range of time slots for the variant. In this case we calculate
+the cheapest possible price of the possible slots. We recommend
+pre-pending the price with 'From' in this case.
+
+The slot which is used to generate the price is included in the data attributes:
+
+{% raw %}
+
+    <span data-variant-pricing-experience-slot-value="<slot id>">
+    </span>
 
 {% endraw %}


### PR DESCRIPTION
We have made two changes to how this tag works this week. More simple to document is `include_fees` parameter.

Additionally, we ensure that a package step item's adopt the price of the slot that will be purchased. This is well defined for items with 'exact' or 'closest match' slot selection strateyg. For those  with a 'range' slot selection strategy, the customer will be asked to select the slot as a following interaction, so we return the cheapest of the slots they can choose from - we recommend pre-pending the price with 'From' in this case.


<img width="980" alt="Screenshot 2025-06-04 at 16 59 28" src="https://github.com/user-attachments/assets/76999469-48e1-4ee3-8d6f-6e3c7cda6b77" />

<img width="980" alt="Screenshot 2025-06-04 at 16 55 56" src="https://github.com/user-attachments/assets/79c16a7a-9677-47ea-ac0f-7cebec97bed6" />

