### PR TITLE
Document utc_offset for products

### DIFF
--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -395,6 +395,13 @@ The url for the product's page on the site.
 
 The product's [useful info]({% link docs/reference/objects/product/useful_info.md %}).
 
+## `product.utc_offset`
+{: .d-inline-block }
+integer
+{: .label .fs-1 }
+
+The product's current observed UTC offset, so you can calculate when 'now' is for the product. This may be negative.
+
 ## `product.variants`
 {: .d-inline-block }
 array of [variant]({% link docs/reference/objects/product/variant/index.md %})s

--- a/docs/reference/objects/product/index.md
+++ b/docs/reference/objects/product/index.md
@@ -400,7 +400,7 @@ The product's [useful info]({% link docs/reference/objects/product/useful_info.m
 integer
 {: .label .fs-1 }
 
-The product's current observed UTC offset, so you can calculate when 'now' is for the product. This may be negative.
+The product's current observed UTC offset in seconds, so you can calculate when 'now' is for the product. This may be negative.
 
 ## `product.variants`
 {: .d-inline-block }


### PR DESCRIPTION
See easol 83a7ddd4fb2c6c05a464b9f85cdf0a966ca23e01 for change to the Easol application.

There are times when the frontend want to know when 'now' is in the product's time zone, so have asked for this to be exposed. Offset in seconds is most useful due to how dates are manipulated in Liquid, where you convert to seconds first.
There are definitely more places we should be doing filtering and converting on the backend but frontend have specifically requested this, so we want to unblock them.


### How to test the changes if manual testing required
<img width="720" height="150" alt="Screenshot 2025-07-28 at 16 50 37" src="https://github.com/user-attachments/assets/27235d5b-d8b0-490d-8698-e7557ad073ce" />

my test block uses:

```
---
product:
  type: product
  label: Product
---

{% assign offset = product.time_zone_offset %}
<p>product.time_zone_offset: {{ offset }}</p>
<p>product.time_zone_offset | divided_by 3600 (i.e. hours): {{ offset | divided_by: 3600 }}</p>

{% assign date_in_s = product.depart_on | date: '%s' %}
<p>product depart_on:  {{ date_in_s | date: "%Y-%m-%d %H:%M" }}</p>
<p>product depart on with timezone adjustment: {{ date_in_s | date: "%s" | plus: offset | date: "%Y-%m-%d %H:%M" }}</p>
```
