### PR TITLE
Add design tokens page for semantic CSS variables

### DIFF
--- a/docs/site_styles/design_tokens.md
+++ b/docs/site_styles/design_tokens.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: Design tokens
+parent: Site styles
+nav_order: 1
+---
+
+# Design tokens
+
+The platform automatically generates a set of CSS custom properties from the four [palette colours]({% link docs/site_styles/index.md %}#colours) defined in Site styles. These variables are injected as `:root` properties at runtime alongside the base palette. They provide accessible, consistent colour tokens for theme development and are computed with WCAG AA compliance in mind (4.5:1 contrast for normal text, 3:1 for large text and UI elements such as borders).
+
+## Colour scales
+
+Four 11-step colour scales (50–950) are generated using the OKLCH colour space for perceptually uniform steps. Each scale is derived from a single source colour.
+
+| Scale | Source | Example variable |
+|-------|--------|------------------|
+| Brand | Primary colour | `--brand-50` through `--brand-950` |
+| Accent | Secondary colour | `--accent-50` through `--accent-950` |
+| Neutral | Site background colour | `--neutral-50` through `--neutral-950` |
+| Error | Fixed (#dc2626) | `--error-50` through `--error-950` |
+
+Steps run from lightest (50) to darkest (950).
+
+## Semantic tokens — Text
+
+| Variable | Description |
+|----------|-------------|
+| `--text-default` | Default body text colour (creator's site text colour) |
+| `--text-muted` | Subdued text; meets 4.5:1 contrast, never more prominent than default |
+| `--text-inverse` | Text for use on inverse (dark/light-flipped) backgrounds; 4.5:1 |
+| `--text-on-brand` | Text on primary-coloured surfaces; white or brand-950, whichever has higher contrast |
+| `--text-on-accent` | Text on secondary-coloured surfaces; white or accent-950 |
+| `--text-on-neutral` | Text on body background; white or neutral-950 |
+
+## Semantic tokens — Backgrounds
+
+| Variable | Description |
+|----------|-------------|
+| `--background-default` | Page background (creator's site background colour) |
+| `--background-muted` | Subtle tinted background for secondary surfaces |
+| `--background-inverse` | Inverse background (same as default text colour) |
+
+## Semantic tokens — Borders
+
+| Variable | Description |
+|----------|-------------|
+| `--border-muted` | Subtle/decorative border |
+| `--border-brand-accessible` | Accessible border from brand scale; 3:1 |
+| `--border-neutral-accessible` | Standard accessible border from neutral scale; 3:1 |
+| `--border-accent-accessible` | Accessible border from accent scale; 3:1 |
+
+## Semantic tokens — Surfaces and errors
+
+| Variable | Description |
+|----------|-------------|
+| `--surface-primary` | Card/modal backgrounds |
+| `--surface-elevated` | Elevated surface (e.g. dropdowns, popovers) |
+| `--error-text` | Error message text; 4.5:1 contrast |
+| `--error-background` | Error background/highlight |
+
+## Usage example
+
+Reference these tokens in your theme CSS instead of hard-coded colours so that colours stay consistent and accessible when Creators change their palette.
+
+```css
+.card {
+  background: var(--surface-primary);
+  color: var(--text-default);
+  border: 1px solid var(--border-default);
+}
+
+.badge {
+  background: var(--primary);
+  color: var(--text-on-brand);
+}
+```

--- a/docs/site_styles/index.md
+++ b/docs/site_styles/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Site styles
+has_children: true
 nav_order: 3
 ---
 
@@ -42,3 +43,5 @@ More than two fonts can be uploaded however they will not automatically be decla
 
 ## Custom CSS
 Custom CSS can be added here that will override the default compiled CSS file (/style.css). This is available to all Creators with or without developer access.
+
+The platform also generates a set of accessible [design tokens]({% link docs/site_styles/design_tokens.md %}) from the four palette colours above. These semantic CSS variables are injected as `:root` variables at runtime and are available for use in your theme.


### PR DESCRIPTION
- Add design_tokens.md under Site styles: colour scales, semantic tokens (text, backgrounds, borders, surfaces/errors), usage example
- Update site_styles index with has_children and link to design tokens