### PR TITLE
Document `product_search` tag filtering

### DIFF
--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -114,6 +114,7 @@ You can use these to construct search filters, e.g.
 - [subcategory]({% link docs/product_search/parameters.md %}#subcategory)
 - [page_size]({% link docs/product_search/parameters.md %}#page_size)
 - [sort]({% link docs/product_search/parameters.md %}#sort)
+- [tag categories]({% link docs/product_search/parameters.md %}#tag-categories)
 
 
 ## Accessing query params

--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -120,10 +120,17 @@ You can use these to construct search filters, e.g.
 ## Accessing query params
 Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that, we can use the `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
 
+The `search` assign is only present when the page URL includes a `search[...]` query string (for example `?search[name]=…` or [tag category]({% link docs/product_search/parameters.md %}#tag-categories) filters). If the request has no `search` query params, `search` is not defined — use `{% if search %}` before reading values so filters and copy stay safe on pages that sometimes load without query params.
+
+Fixed search keys use dot or bracket syntax (for example `search.departure_date` or `{{ search["departure_date"] }}`). [Tag category]({% link docs/product_search/parameters.md %}#tag-categories) values from the URL are read with the category name in brackets, for example `{{ search["Amenities"] }}` (names and spacing must match the company’s tag category).
+
 ##### syntax
 {% raw %}
-```
-{{ search.departure_date }}
+```liquid
+{% if search %}
+  {{ search.departure_date }}
+  {{ search["Amenities"] }}
+{% endif %}
 ```
 {% endraw %}
 

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -294,3 +294,25 @@ Will determine the order of the returned products.
 ```
 https://mysite.com/search?search[sort]=departure_date_asc
 ```
+
+### tag categories
+Products can be filtered by their tag categories and values. Tag categories and values are defined per company — consult the company for available tags.
+
+Filtering returns products that match at least one of the provided values in _all_ of the filtered categories (AND across categories, OR within a category).
+
+Tag-based filtering is only available as a query parameter — it cannot be passed as a search tag attribute.
+
+For **accommodations**, star rating is a separate product field (not a tag). Use tag categories for other merchandising-style filters (for example **Amenities**, **Difficulty**, **Distance**).
+
+##### as a query parameter
+```
+https://mysite.com/search?search[Difficulty][]=Easy
+https://mysite.com/search?search[Difficulty][]=Easy&search[Difficulty][]=Moderate
+https://mysite.com/search?search[Amenities][]=Pool&search[Difficulty][]=Hard
+```
+
+##### examples
+- `?search[Difficulty][]=Easy` — Products tagged **Easy** under **Difficulty** only.
+- `?search[Difficulty][]=Easy&search[Difficulty][]=Moderate` — Products tagged **Easy** or **Moderate** under **Difficulty** (OR within the same category).
+- `?search[Amenities][]=Pool&search[Difficulty][]=Hard` — Products tagged **Pool** under **Amenities** and **Hard** under **Difficulty** (AND across categories).
+- `?search[Amenities][]=Pool&search[Amenities][]=Gym&search[Difficulty][]=Hard` — Products tagged **Pool** or **Gym** under **Amenities**, and **Hard** under **Difficulty**.

--- a/docs/product_search/parameters.md
+++ b/docs/product_search/parameters.md
@@ -316,3 +316,5 @@ https://mysite.com/search?search[Amenities][]=Pool&search[Difficulty][]=Hard
 - `?search[Difficulty][]=Easy&search[Difficulty][]=Moderate` — Products tagged **Easy** or **Moderate** under **Difficulty** (OR within the same category).
 - `?search[Amenities][]=Pool&search[Difficulty][]=Hard` — Products tagged **Pool** under **Amenities** and **Hard** under **Difficulty** (AND across categories).
 - `?search[Amenities][]=Pool&search[Amenities][]=Gym&search[Difficulty][]=Hard` — Products tagged **Pool** or **Gym** under **Amenities**, and **Hard** under **Difficulty**.
+
+In Liquid, the same values are available on the `search` object when the URL includes these params, for example `{{ search["Amenities"] }}`. See [Accessing query params]({% link docs/product_search/index.md %}#accessing-query-params) and the [Search]({% link docs/reference/objects/search_query.md %}) object reference.

--- a/docs/reference/objects/search_query.md
+++ b/docs/reference/objects/search_query.md
@@ -9,6 +9,12 @@ parent: Objects
 object
 {: .label .fs-1 }
 
+The Search object reflects permitted `search[...]` query parameters from the current page URL. It is only assigned when the request includes a `search` query string; otherwise `search` is not defined in Liquid — use `{% if search %}` before accessing it.
+
+Use dot syntax for the fixed attributes documented below (for example `search.name`). You can also use bracket syntax for those keys (for example `{{ search["departure_date"] }}`).
+
+[Tag category]({% link docs/product_search/parameters.md %}#tag-categories) filters from the URL are exposed on the same object with bracket syntax and the category name as it appears in the query, for example `{{ search["Amenities"] }}` or `{{ search["Difficulty"] }}`. There is no `search.amenities`-style dot accessor for dynamic category names.
+
 #### Attributes
 
 ## `search.active_promotion`

--- a/docs/reference/tags/product_search/index.md
+++ b/docs/reference/tags/product_search/index.md
@@ -174,6 +174,31 @@ e.g.
 
 Params passed through a query param will overwrite any of those specified as an attribute
 
+## Tag-based filtering
+
+If the company has added tags to their products, these can be used to filter the results outputted by the search tag.
+
+Product tags are textual values that identify attributes of the products. They are grouped under categories which the company is also able to define.
+
+Some examples of these might be **Amenities**, **Difficulty**, **Distance**, etc. Consult the company for the available tags and categories.
+
+Star rating for **accommodations** is a separate product field, not a tag — do not use tag categories to represent it in examples.
+
+**Syntax**
+
+`product_search` filters results if one or more `search` query parameters are present in the URL. The search query parameters are in the format `search[<tag category>][]=<tag value>`; add as many as needed to filter the results.
+
+You can specify multiple categories and values by repeating the `search[][]` query parameter.
+
+Filtering returns products that match at least one of the provided values in _all_ of the filtered categories.
+
+**Examples**
+
+- `?search[Difficulty][]=Easy` - Products tagged **Easy** under **Difficulty** only.
+- `?search[Difficulty][]=Easy&search[Difficulty][]=Moderate` - Products tagged **Easy** or **Moderate** under **Difficulty**.
+- `?search[Amenities][]=Pool&search[Difficulty][]=Hard` - Products tagged **Pool** under **Amenities** and **Hard** under **Difficulty**.
+- `?search[Amenities][]=Pool&search[Amenities][]=Gym&search[Difficulty][]=Hard` - Products tagged **Pool** or **Gym** under **Amenities**, and **Hard** under **Difficulty**.
+
 ## Sorting
 
 It's possible to also sort the results by name, departure date and duration. This can be done either through an attribute on the tag or through the search query param.

--- a/docs/reference/tags/product_search/index.md
+++ b/docs/reference/tags/product_search/index.md
@@ -75,7 +75,7 @@ The product search returns `available_months`, an array of `Date` objects, which
 
 Each `Date` is dated 1st of the month, and there is one for each month in which a product's slot `start_on` date occurs.
 
-E.g. Today is `1st Jan 2024``. You have a product with a 10 day duration, with the following slots (all future or ongoing);
+E.g. Today is `1st Jan 2024`. You have a product with a 10 day duration, with the following slots (all future or ongoing);
 - `31th Dec 2023`
 - `15th Jan 2024`
 - `20th Jan 2024`
@@ -228,14 +228,18 @@ or
 ## Accessing the query params
 
 Once the search has been executed, it can be helpful to get a reference to the params and values in the search.
-For that, we can use the `Search` object, which exposes all of the params listed above in the "Passing explicit attributes" section.
+For that, we can use the [Search]({% link docs/reference/objects/search_query.md %}) object. It exposes the fixed params listed under [Passing explicit attributes](#passing-explicit-attributes) when they appear in the URL’s `search[...]` query string.
+
+The `search` assign is only defined when the request includes those query params. On pages that can load with or without a `search` query, wrap reads in `{% if search %}`. See also [Product search — Accessing query params]({% link docs/product_search/index.md %}#accessing-query-params).
+
+[Tag-based filtering](#tag-based-filtering) values from the URL are not separate assigns: read them on the same object with the category name in brackets, for example `{{ search["Difficulty"] }}` or `{{ search["Amenities"] }}` (match the company’s category name exactly).
 
 {% raw %}
 ```liquid
-{{ search.departure_date }}
-
-or
-
-{{ search["departure_date"] }}
+{% if search %}
+  {{ search.departure_date }}
+  {{ search["departure_date"] }}
+  {{ search["Amenities"] }}
+{% endif %}
 ```
 {% endraw %}


### PR DESCRIPTION
Documents how `product_search` accepts **per-company tag category** filters via query params (`search[<category>][]=…`), aligned with `package_step_product_search`. Examples use neutral categories (**Amenities**, **Difficulty**) rather than star rating, since star rating for accommodations is a separate product field, not a tag.

Relevant changes: https://github.com/easolhq/easol/pull/20782