### PR TITLE
fix: Jekyll build: escape inline `{% if search %}` in docs

### DIFF
--- a/docs/product_search/index.md
+++ b/docs/product_search/index.md
@@ -120,7 +120,7 @@ You can use these to construct search filters, e.g.
 ## Accessing query params
 Once the search has been executed, it can be helpful to get a reference to the params and values in the search. For that, we can use the `search` [Search]({% link docs/reference/objects/search_query.md %}) object.
 
-The `search` assign is only present when the page URL includes a `search[...]` query string (for example `?search[name]=…` or [tag category]({% link docs/product_search/parameters.md %}#tag-categories) filters). If the request has no `search` query params, `search` is not defined — use `{% if search %}` before reading values so filters and copy stay safe on pages that sometimes load without query params.
+The `search` assign is only present when the page URL includes a `search[...]` query string (for example `?search[name]=…` or [tag category]({% link docs/product_search/parameters.md %}#tag-categories) filters). If the request has no `search` query params, `search` is not defined — use {% raw %}`{% if search %}`{% endraw %} before reading values so filters and copy stay safe on pages that sometimes load without query params.
 
 Fixed search keys use dot or bracket syntax (for example `search.departure_date` or `{{ search["departure_date"] }}`). [Tag category]({% link docs/product_search/parameters.md %}#tag-categories) values from the URL are read with the category name in brackets, for example `{{ search["Amenities"] }}` (names and spacing must match the company’s tag category).
 

--- a/docs/reference/objects/search_query.md
+++ b/docs/reference/objects/search_query.md
@@ -9,7 +9,7 @@ parent: Objects
 object
 {: .label .fs-1 }
 
-The Search object reflects permitted `search[...]` query parameters from the current page URL. It is only assigned when the request includes a `search` query string; otherwise `search` is not defined in Liquid — use `{% if search %}` before accessing it.
+The Search object reflects permitted `search[...]` query parameters from the current page URL. It is only assigned when the request includes a `search` query string; otherwise `search` is not defined in Liquid — use {% raw %}`{% if search %}`{% endraw %} before accessing it.
 
 Use dot syntax for the fixed attributes documented below (for example `search.name`). You can also use bracket syntax for those keys (for example `{{ search["departure_date"] }}`).
 

--- a/docs/reference/tags/product_search/index.md
+++ b/docs/reference/tags/product_search/index.md
@@ -230,7 +230,7 @@ or
 Once the search has been executed, it can be helpful to get a reference to the params and values in the search.
 For that, we can use the [Search]({% link docs/reference/objects/search_query.md %}) object. It exposes the fixed params listed under [Passing explicit attributes](#passing-explicit-attributes) when they appear in the URL’s `search[...]` query string.
 
-The `search` assign is only defined when the request includes those query params. On pages that can load with or without a `search` query, wrap reads in `{% if search %}`. See also [Product search — Accessing query params]({% link docs/product_search/index.md %}#accessing-query-params).
+The `search` assign is only defined when the request includes those query params. On pages that can load with or without a `search` query, wrap reads in {% raw %}`{% if search %}`{% endraw %}. See also [Product search — Accessing query params]({% link docs/product_search/index.md %}#accessing-query-params).
 
 [Tag-based filtering](#tag-based-filtering) values from the URL are not separate assigns: read them on the same object with the category name in brackets, for example `{{ search["Difficulty"] }}` or `{{ search["Amenities"] }}` (match the company’s category name exactly).
 


### PR DESCRIPTION
Inline code examples used backticks around real Liquid tags, so Jekyll parsed them as tags and failed with an unclosed if. Wrap those snippets in raw/endraw so they render as documentation only.